### PR TITLE
Prereleases semver

### DIFF
--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -32,7 +32,7 @@ runs:
     - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b
       id: tag
       with:
-        text: ${{ steps.packageVersion.outputs.prop }}
+        text: ${{ steps.versionSuffix.outputs.prerelease }}
         # at this point, we have just the prerelease section, but it includes the final .0 or whatever
         regex: '.*(?=.\d+)'
 

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -3,7 +3,7 @@ description: read package.json and return the version suffix (ex 'beta' if x.y.z
 
 outputs:
   tag:
-    value: ${{ steps.versionSuffix.outputs.prerelease }}
+    value: ${{ steps.tag.outputs.match }}
     description: version suffix (ex 'beta' if x.y.z-beta.0 ), if exists in package.json
   version:
     value: ${{ steps.packageVersion.outputs.prop }}
@@ -26,5 +26,15 @@ runs:
       with:
         input_string: ${{ steps.packageVersion.outputs.prop }}
 
-    - run: echo "found tag ${{ steps.versionSuffix.outputs.prerelease }}"
+    - run: echo "found prerelease ${{ steps.versionSuffix.outputs.prerelease }}"
+      shell: bash
+
+    - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b
+      id: tag
+      with:
+        text: ${{ steps.packageVersion.outputs.prop }}
+        # at this point, we have just the prerelease section, but it includes the final .0 or whatever
+        regex: '.*(?=.\d+)'
+
+    - run: echo "found tag ${{ steps.tag.outputs.match }}"
       shell: bash

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -1,0 +1,32 @@
+name: get prerelease tag
+description: read package.json and return the version suffix (ex 'beta' if x.y.z-beta.0)
+
+outputs:
+  tag:
+    value: ${{ steps.versionSuffix.outputs.match }}
+    description: version suffix (ex 'beta' if x.y.z-beta.0 ), if exists in package.json
+  version:
+    value: ${{ steps.packageVersion.outputs.prop }}
+    description: version from pjson
+
+runs:
+  using: composite
+  steps:
+    - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
+      id: packageVersion
+      with:
+        path: "package.json"
+        prop_path: "version"
+
+    - run: echo "found version ${{ steps.packageVersion.outputs.prop  }}"
+      shell: bash
+
+    - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b
+      id: versionSuffix
+      with:
+        text: ${{ steps.packageVersion.outputs.prop }}
+        # handle both 1.1.1-beta.0 and 1.1.1-beta
+        regex: '(?<=\d*\.\d*\.\d*-)\w+'
+
+    - run: echo "found tag ${{ steps.versionSuffix.outputs.match }}"
+      shell: bash

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -34,7 +34,7 @@ runs:
       with:
         text: ${{ steps.versionSuffix.outputs.prerelease }}
         # at this point, we have just the prerelease section, but it includes the final .0 or whatever
-        regex: '.*(?=.\d+)'
+        regex: '.*(?=\.\d+)'
 
     - run: echo "found tag ${{ steps.tag.outputs.match }}"
       shell: bash

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         text: ${{ steps.packageVersion.outputs.prop }}
         # handle both 1.1.1-beta.0 and 1.1.1-beta
-        regex: '(?<=\d*\.\d*\.\d*-)\w+'
+        regex: '(?<=\d*\.\d*\.\d*-)[\w]*[a-z|A-Z]+[\w]*'
 
     - run: echo "found tag ${{ steps.versionSuffix.outputs.match }}"
       shell: bash

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -3,7 +3,7 @@ description: read package.json and return the version suffix (ex 'beta' if x.y.z
 
 outputs:
   tag:
-    value: ${{ steps.versionSuffix.outputs.match }}
+    value: ${{ steps.versionSuffix.outputs.prerelease }}
     description: version suffix (ex 'beta' if x.y.z-beta.0 ), if exists in package.json
   version:
     value: ${{ steps.packageVersion.outputs.prop }}
@@ -26,5 +26,5 @@ runs:
       with:
         input_string: ${{ steps.packageVersion.outputs.prop }}
 
-    - run: echo "found tag ${{ steps.versionSuffix.outputs.match }}"
+    - run: echo "found tag ${{ steps.versionSuffix.outputs.prerelease }}"
       shell: bash

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -21,12 +21,10 @@ runs:
     - run: echo "found version ${{ steps.packageVersion.outputs.prop  }}"
       shell: bash
 
-    - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b
+    - uses: booxmedialtd/ws-action-parse-semver@e4a833cf5d612066a210bd9b62d1c3b20be3b325
       id: versionSuffix
       with:
-        text: ${{ steps.packageVersion.outputs.prop }}
-        # handle both 1.1.1-beta.0 and 1.1.1-beta
-        regex: '(?<=\d*\.\d*\.\d*-)[\w]*[a-z|A-Z]+[\w]*'
+        input_string: ${{ steps.packageVersion.outputs.prop }}
 
     - run: echo "found tag ${{ steps.versionSuffix.outputs.match }}"
       shell: bash

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -15,6 +15,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.SF_CLI_BOT_GITHUB_TOKEN }}
+
+      - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@prereleases-semver
+        id: distTag
+        if: inputs.prerelease
+
+      - name: prerelease package.json validation
+        if: inputs.prerelease && !steps.distTag.outputs.tag
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Prerelease requires a dist tag name in your package.json like beta in 1.1.1-beta.0')
+
       - name: Conventional Changelog Action
         id: changelog
         uses: salesforcecli/conventional-changelog-action@prereleases

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -1,6 +1,12 @@
 name: tag and github release
 on:
   workflow_call:
+    inputs:
+      prerelease:
+        type: boolean
+        required: false
+        default: false
+        description: use a prerelease instead of a regular release
 
 jobs:
   release:
@@ -27,3 +33,4 @@ jobs:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
+          prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -11,7 +11,7 @@ jobs:
           token: ${{ secrets.SF_CLI_BOT_GITHUB_TOKEN }}
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@d360fad3a42feca6462f72c97c165d60a02d4bf2
+        uses: salesforcecli/conventional-changelog-action@prereleases
         with:
           git-user-name: SF-CLI-BOT
           git-user-email: alm-cli@salesforce.com

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Use this repo's `npmPublish` if you need either
 
 ### githubRelease
 
-> creates a github release based on conventional commit prefixes. Using commits like `fix: etc` (patch version) and `feat: wow` (minor version) or any valid prefix with a `!` like `feat!:` (major version) will cause the action to update the packageVersion, produce a changelog, tag and release.
+> creates a github release based on conventional commit prefixes. Using commits like `fix: etc` (patch version) and `feat: wow` (minor version).
+> A commit whose **body** (not the title) contains `BREAKING CHANGES:` will cause the action to update the packageVersion to the next major version, produce a changelog, tag and release.
 
 ```yml
 name: version, tag and github release
@@ -198,6 +199,7 @@ jobs:
 ```
 
 ### prNotification
+
 > Mainly used to notify Slack when Pull Requests are opened.
 >
 > For more info see [.github/actions/prNotification/README.md](.github/actions/prNotification/README.md)
@@ -213,17 +215,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Notify Slack on PR open
-      env: 
-        WEBHOOK_URL : ${{ secrets.SLACK_WEBHOOK_URL }}
-        PULL_REQUEST_AUTHOR_ICON_URL : ${{ github.event.pull_request.user.avatar_url }}
-        PULL_REQUEST_AUTHOR_NAME : ${{ github.event.pull_request.user.login }}
-        PULL_REQUEST_AUTHOR_PROFILE_URL: ${{ github.event.pull_request.user.html_url }}
-        PULL_REQUEST_BASE_BRANCH_NAME : ${{ github.event.pull_request.base.ref }}
-        PULL_REQUEST_COMPARE_BRANCH_NAME : ${{ github.event.pull_request.head.ref }}
-        PULL_REQUEST_NUMBER : ${{ github.event.pull_request.number }}
-        PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.name }}
-        PULL_REQUEST_TITLE : ${{ github.event.pull_request.title }}
-        PULL_REQUEST_URL : ${{ github.event.pull_request.html_url }}
-      uses: salesforcecli/github-workflows/.github/actions/prNotification@main
+      - name: Notify Slack on PR open
+        env:
+          WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PULL_REQUEST_AUTHOR_ICON_URL: ${{ github.event.pull_request.user.avatar_url }}
+          PULL_REQUEST_AUTHOR_NAME: ${{ github.event.pull_request.user.login }}
+          PULL_REQUEST_AUTHOR_PROFILE_URL: ${{ github.event.pull_request.user.html_url }}
+          PULL_REQUEST_BASE_BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
+          PULL_REQUEST_COMPARE_BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.name }}
+          PULL_REQUEST_TITLE: ${{ github.event.pull_request.title }}
+          PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+        uses: salesforcecli/github-workflows/.github/actions/prNotification@main
 ```


### PR DESCRIPTION
uses https://github.com/salesforcecli/conventional-changelog-action/tree/prereleases


the onRelease and onPushToMain workflows in your qa repo should look more like these: 

https://github.com/salesforcecli/testPackageRelease/blob/prerelease/demo/.github/workflows/onRelease.yml
https://github.com/salesforcecli/testPackageRelease/blob/prerelease/demo/.github/workflows/onPushToMain.yml

And, modify your package.json version to include the prerelease name and give it a starting number (x.x.x-beta.0) so that the workflows recognize it as a prerelease