### PR TITLE
feat: rename intel mac pkg

### DIFF
--- a/.github/actions/renameMacPkg/action.yml
+++ b/.github/actions/renameMacPkg/action.yml
@@ -14,9 +14,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: download & rename -x64.pkg
+    - id: download-and-rename-x64-pkg
       shell: bash
       run: aws s3 cp s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/sfdx-x64.pkg ./sfdx.pkg
-    - id: upload renamed .pkg
+    - id: upload-renamed-pkg
       shell: bash
       run: aws s3 cp ./sfdx.pkg s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/

--- a/.github/actions/renameMacPkg/action.yml
+++ b/.github/actions/renameMacPkg/action.yml
@@ -1,0 +1,22 @@
+# This action is only needed as long as the developer site and other docs are linking to the old sfdx.pkg file and the mac signing job is only signing the old file as well.
+# It can be deleted once those are updated to use the new name, sfdx-x64.pkg.
+name: rename-mac-pkg
+description: renames the intel mac pkg file created by oclif v3 to match the name of the file created by oclif v2
+
+inputs:
+  cli: 
+    description: which CLI to rename the pkg file for (e.g. sfdx or sf)
+    required: true
+  channel:
+    description: cli channel to target (e.g. stable, stable-rc)
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: download & rename -x64.pkg
+      shell: bash
+      run: aws s3 cp s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/sfdx-x64.pkg ./sfdx.pkg
+    - id: upload renamed .pkg
+      shell: bash
+      run: aws s3 cp ./sfdx.pkg s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -33,3 +33,16 @@ jobs:
       - run: yarn upload:macos
       - run: yarn channel:promote --cli ${{ inputs.cli }} --version ${{ inputs.version }} --target ${{ inputs.channel }} --platform macos
         name: Promote macos to ${{ inputs.channel }} channel
+  # The rename-mac-pkg job is only needed as long as the developer site is linking to the old sfdx.pkg file and the mac signing job is only signing the old file as well.
+  # It can be removed once those are updated to use the new name, sfdx-x64.pkg.
+  rename-mac-pkg:
+    runs-on: ubuntu-latest
+    container:
+      image: amazon/aws-cli:2.8.6
+      env: 
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    needs: [macos]
+    steps:
+      - run: aws s3 cp s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/sfdx-x64.pkg ./sfdx.pkg
+      - run: aws s3 cp ./sfdx.pkg s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -37,12 +37,10 @@ jobs:
   # It can be removed once those are updated to use the new name, sfdx-x64.pkg.
   rename-mac-pkg:
     runs-on: ubuntu-latest
-    container:
-      image: amazon/aws-cli:2.8.6
-      env: 
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_EC2_METADATA_DISABLED: true
+    env: 
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
     needs: [macos]
     steps:
       - run: aws s3 cp s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/sfdx-x64.pkg ./sfdx.pkg

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -42,6 +42,7 @@ jobs:
       env: 
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_EC2_METADATA_DISABLED: true
     needs: [macos]
     steps:
       - run: aws s3 cp s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/sfdx-x64.pkg ./sfdx.pkg

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -33,6 +33,7 @@ jobs:
       - run: yarn upload:macos
       - run: yarn channel:promote --cli ${{ inputs.cli }} --version ${{ inputs.version }} --target ${{ inputs.channel }} --platform macos
         name: Promote macos to ${{ inputs.channel }} channel
+  
   # The rename-mac-pkg job is only needed as long as the developer site is linking to the old sfdx.pkg file and the mac signing job is only signing the old file as well.
   # It can be removed once those are updated to use the new name, sfdx-x64.pkg.
   rename-mac-pkg:
@@ -43,5 +44,7 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
     needs: [macos]
     steps:
-      - run: aws s3 cp s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/sfdx-x64.pkg ./sfdx.pkg
-      - run: aws s3 cp ./sfdx.pkg s3://dfc-data-production/media/salesforce-cli/${{ inputs.cli }}/channels/${{ inputs.channel }}/
+      - uses: salesforcecli/github-workflows/.github/actions/renameMacPkg@main
+        with:
+          cli: ${{ inputs.cli }}
+          channel: ${{ inputs.channel }}

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -44,7 +44,7 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
     needs: [macos]
     steps:
-      - uses: salesforcecli/github-workflows/.github/actions/renameMacPkg@main
+      - uses: salesforcecli/github-workflows/.github/actions/renameMacPkg@re/rename-mac-pkg
         with:
           cli: ${{ inputs.cli }}
           channel: ${{ inputs.channel }}

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -44,7 +44,7 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
     needs: [macos]
     steps:
-      - uses: salesforcecli/github-workflows/.github/actions/renameMacPkg@re/rename-mac-pkg
+      - uses: salesforcecli/github-workflows/.github/actions/renameMacPkg@main
         with:
           cli: ${{ inputs.cli }}
           channel: ${{ inputs.channel }}

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -33,18 +33,3 @@ jobs:
       - run: yarn upload:macos
       - run: yarn channel:promote --cli ${{ inputs.cli }} --version ${{ inputs.version }} --target ${{ inputs.channel }} --platform macos
         name: Promote macos to ${{ inputs.channel }} channel
-  
-  # The rename-mac-pkg job is only needed as long as the developer site is linking to the old sfdx.pkg file and the mac signing job is only signing the old file as well.
-  # It can be removed once those are updated to use the new name, sfdx-x64.pkg.
-  rename-mac-pkg:
-    runs-on: ubuntu-latest
-    env: 
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_EC2_METADATA_DISABLED: true
-    needs: [macos]
-    steps:
-      - uses: salesforcecli/github-workflows/.github/actions/renameMacPkg@main
-        with:
-          cli: ${{ inputs.cli }}
-          channel: ${{ inputs.channel }}


### PR DESCRIPTION
> This needs to be merged at the same time as https://github.com/salesforcecli/sfdx-cli/pull/717

### What does this PR do?
Adds a job to the workflow that packages and uploads Mac installers to copy & rename the intel Mac `.pkg` file produced by oclif from `<myCLI>-x64.pkg` to `<myCLI>.pkg` to avoid a breaking change for the `sfdx` CLI's download URLs.

### What issues does this PR fix or reference?
@W-11963360@
