### PR TITLE
feat: caching, optimizations, retries

### DIFF
--- a/.github/actions/windowsCachePerf/action.yml
+++ b/.github/actions/windowsCachePerf/action.yml
@@ -1,0 +1,12 @@
+name: windowsCachePerfBoost
+description: "Sets git username/email and push behavior"
+runs:
+  using: composite
+  steps:
+    # improve windows cache perf.  See https://github.com/actions/cache/blob/main/workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
+    - if: ${{ runner.os == 'Windows' }}
+      name: Use GNU tar
+      shell: cmd
+      run: |
+        echo "Adding GNU tar to PATH"
+        echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -51,6 +51,13 @@ on:
 
 jobs:
   external-nut:
+    env:
+      TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL }}
+      TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
+      TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
+      TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
+      TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
+      TESTKIT_SETUP_RETRIES: 2
     name: ${{ inputs.command }}
     runs-on: ${{ inputs.os }}
     steps:
@@ -96,17 +103,7 @@ jobs:
         if: inputs.sfdxExecutablePath
         env:
           TESTKIT_EXECUTABLE_PATH: ${{ inputs.sfdxExecutablePath }}
-          TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL }}
-          TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
-          TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
-          TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
-          TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
+
       - name: NUTs
         run: ${{ inputs.command }}
         if: ${{ !inputs.sfdxExecutablePath }}
-        env:
-          TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL }}
-          TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
-          TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
-          TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
-          TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -98,12 +98,21 @@ jobs:
         run: ${{ inputs.preExternalBuildCommands }}
       - name: Build the external project (where the NUTs are)
         run: yarn compile
-      - name: NUTs with custom executable
-        run: ${{ inputs.command }}
+      - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
         if: inputs.sfdxExecutablePath
-        env:
-          TESTKIT_EXECUTABLE_PATH: ${{ inputs.sfdxExecutablePath }}
-
-      - name: NUTs
+      - name: NUTs attempt 1
+        continue-on-error: true
+        id: nut1
         run: ${{ inputs.command }}
-        if: ${{ !inputs.sfdxExecutablePath }}
+      - name: NUTs attempt 2
+        continue-on-error: true
+        id: nut2
+        if: steps.nut1.outcome == 'failure'
+        run: |
+          echo "::notice title=NUT Retry::NUT '${{input.command}}' failed and was retried."
+          ${{ inputs.command }}
+      - name: NUTs attempt 3
+        if: steps.nut2.outcome == 'failure'
+        run: |
+          echo "::warning title=NUT Retry 2::NUT '${{input.command}}' failed twice and was retried."
+          ${{ inputs.command }}

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -109,10 +109,10 @@ jobs:
         id: nut2
         if: steps.nut1.outcome == 'failure'
         run: |
-          echo "::notice title=NUT Retry::NUT '${{input.command}}' failed and was retried."
+          echo "::notice title=NUT Retry::NUT '${{inputs.command}}' failed and was retried."
           ${{ inputs.command }}
       - name: NUTs attempt 3
         if: steps.nut2.outcome == 'failure'
         run: |
-          echo "::warning title=NUT Retry 2::NUT '${{input.command}}' failed twice and was retried."
+          echo "::warning title=NUT Retry 2::NUT '${{inputs.command}}' failed twice and was retried."
           ${{ inputs.command }}

--- a/.github/workflows/lockFileCheck.yml
+++ b/.github/workflows/lockFileCheck.yml
@@ -1,0 +1,11 @@
+on: workflow_call
+
+jobs:
+  lockfile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: |
+          npm install -g lockfile-lint
+          lockfile-lint --path yarn.lock --allowed-hosts npm yarn --validate-https

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -34,6 +34,7 @@ jobs:
       TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
       TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
       ONEGP_TESTKIT_AUTH_URL: ${{ secrets.ONEGP_TESTKIT_AUTH_URL }}
+      TESTKIT_SETUP_RETRIES: 2
     name: ${{ inputs.command }}
     runs-on: ${{ inputs.os }}
     steps:

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -48,6 +48,8 @@ jobs:
         id: yarnGlobalDir
       - run: echo "yarnGlobalBin=$(yarn global bin)" >> $GITHUB_OUTPUT
         id: yarnGlobalBin
+      - run: echo "dir ${{ steps.yarnGlobalDir.outputs.yarnGlobalDir}}"
+      - run: echo "bin ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}"
       - name: Cache node modules
         id: cache-nodemodules
         uses: actions/cache@v3

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -43,13 +43,6 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: yarn
-      # dynamically get the os-specific locations for the yarn global installs of the CLI
-      - run: echo "yarnGlobalDir=$(yarn global dir)" >> $GITHUB_OUTPUT
-        id: yarnGlobalDir
-      - run: echo "yarnGlobalBin=$(yarn global bin)" >> $GITHUB_OUTPUT
-        id: yarnGlobalBin
-      - run: echo "dir ${{ steps.yarnGlobalDir.outputs.yarnGlobalDir}}"
-      - run: echo "bin ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}"
       - name: Cache node modules
         id: cache-nodemodules
         uses: actions/cache@v3
@@ -58,18 +51,7 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-      - name: Cache yarn globals
-        id: cache-yarnGlobals
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-yarn-globals
-        with:
-          path: |
-            ${{ steps.yarnGlobalDir.outputs.yarnGlobalDir}}
-            ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}
-          key: ${{ runner.os }}-${{ env.cache-name }}
       - run: yarn global add sfdx-cli @salesforce/cli
-        if: ${{ steps.cache-yarnGlobals.outputs.cache-hit != 'true' }}
       - run: yarn install --network-timeout 600000
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -57,15 +57,9 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
       - run: yarn compile
-      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || \
-          (echo "NUTs attempt 2:" && ${{ inputs.command }}) || \
-          (echo "NUTs attempt 3:" && ${{ inputs.command }}) || \
-          (echo "NUTs failed!" && exit 1)
+      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || (echo "NUTs attempt 2:" && ${{ inputs.command }}) || (echo "NUTs attempt 3:" && ${{ inputs.command }}) || (echo "NUTs failed!" && exit 1)
         if: inputs.sfdxExecutablePath != ''
         env:
           TESTKIT_EXECUTABLE_PATH: ${{ inputs.sfdxExecutablePath }}
-      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || \
-          (echo "NUTs attempt 2:" && ${{ inputs.command }}) || \
-          (echo "NUTs attempt 3:" && ${{ inputs.command }}) || \
-          (echo "NUTs failed!" && exit 1)
+      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || (echo "NUTs attempt 2:" && ${{ inputs.command }}) || (echo "NUTs attempt 3:" && ${{ inputs.command }}) || (echo "NUTs failed!" && exit 1)
         if: inputs.sfdxExecutablePath == ''

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -57,9 +57,15 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
       - run: yarn compile
-      - run: ${{ inputs.command }}
+      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || \
+          (echo "NUTs attempt 2:" && ${{ inputs.command }}) || \
+          (echo "NUTs attempt 3:" && ${{ inputs.command }}) || \
+          (echo "NUTs failed!" && exit 1)
         if: inputs.sfdxExecutablePath != ''
         env:
           TESTKIT_EXECUTABLE_PATH: ${{ inputs.sfdxExecutablePath }}
-      - run: ${{ inputs.command }}
+      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || \
+          (echo "NUTs attempt 2:" && ${{ inputs.command }}) || \
+          (echo "NUTs attempt 3:" && ${{ inputs.command }}) || \
+          (echo "NUTs failed!" && exit 1)
         if: inputs.sfdxExecutablePath == ''

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -43,15 +43,24 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: yarn
+      # dynamically get the os-specific locations for the yarn global installs of the CLI
+      - run: echo "{yarnGlobalDir}=yarn global dir" >> $GITHUB_OUTPUT
+        id: yarnGlobalDir
+      - run: echo "{yarnGlobalBin}=yarn global bin" >> $GITHUB_OUTPUT
+        id: yarnGlobalBin
       - name: Cache node modules
         id: cache-nodemodules
         uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
-          path: "**/node_modules"
+          path: |
+            "**/node_modules"
+            ${{ steps.yarnGlobalDir.outputs.yarnGlobalDir}}
+            ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn global add sfdx-cli @salesforce/cli
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn install --network-timeout 600000
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -52,13 +52,20 @@ jobs:
         id: cache-nodemodules
         uses: actions/cache@v3
         env:
-          cache-name: cache-node-modules-yarn-globals
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Cache yarn globals
+        id: cache-yarnGlobals
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-yarn-globals
         with:
           path: |
-            "**/node_modules"
             ${{ steps.yarnGlobalDir.outputs.yarnGlobalDir}}
             ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}
       - run: yarn global add sfdx-cli @salesforce/cli
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn install --network-timeout 600000

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -44,9 +44,9 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
           cache: yarn
       # dynamically get the os-specific locations for the yarn global installs of the CLI
-      - run: echo "{yarnGlobalDir}=yarn global dir" >> $GITHUB_OUTPUT
+      - run: echo "yarnGlobalDir=yarn global dir" >> $GITHUB_OUTPUT
         id: yarnGlobalDir
-      - run: echo "{yarnGlobalBin}=yarn global bin" >> $GITHUB_OUTPUT
+      - run: echo "yarnGlobalBin=yarn global bin" >> $GITHUB_OUTPUT
         id: yarnGlobalBin
       - name: Cache node modules
         id: cache-nodemodules
@@ -67,7 +67,7 @@ jobs:
             ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}
           key: ${{ runner.os }}-${{ env.cache-name }}
       - run: yarn global add sfdx-cli @salesforce/cli
-        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-yarnGlobals.outputs.cache-hit != 'true' }}
       - run: yarn install --network-timeout 600000
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -49,7 +49,7 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn global add sfdx-cli @salesforce/cli
       - run: yarn install --network-timeout 600000
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: yarn
-      - run: npm install -g sfdx-cli @salesforce/cli --omit=dev
+      - run: yarn global add sfdx-cli @salesforce/cli
       - run: yarn install --network-timeout 600000
       - run: yarn compile
       - run: ${{ inputs.command }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -42,8 +42,18 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: yarn
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - run: yarn global add sfdx-cli @salesforce/cli
       - run: yarn install --network-timeout 600000
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+
       - run: yarn compile
       - run: ${{ inputs.command }}
         if: inputs.sfdxExecutablePath != ''

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@yarn-global-install
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.nodeVersion }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@yarn-global-install
+      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@main
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.nodeVersion }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -44,9 +44,9 @@ jobs:
           node-version: ${{ inputs.nodeVersion }}
           cache: yarn
       # dynamically get the os-specific locations for the yarn global installs of the CLI
-      - run: echo "yarnGlobalDir=yarn global dir" >> $GITHUB_OUTPUT
+      - run: echo "yarnGlobalDir=$(yarn global dir)" >> $GITHUB_OUTPUT
         id: yarnGlobalDir
-      - run: echo "yarnGlobalBin=yarn global bin" >> $GITHUB_OUTPUT
+      - run: echo "yarnGlobalBin=$(yarn global bin)" >> $GITHUB_OUTPUT
         id: yarnGlobalBin
       - name: Cache node modules
         id: cache-nodemodules

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -67,10 +67,10 @@ jobs:
         id: nut2
         if: steps.nut1.outcome == 'failure'
         run: |
-          echo "::notice title=NUT Retry::NUT '${{input.command}}' failed and was retried."
+          echo "::notice title=NUT Retry::NUT '${{inputs.command}}' failed and was retried."
           ${{ inputs.command }}
       - name: NUTs attempt 3
         if: steps.nut2.outcome == 'failure'
         run: |
-          echo "::warning title=NUT Retry 2::NUT '${{input.command}}' failed twice and was retried."
+          echo "::warning title=NUT Retry 2::NUT '${{inputs.command}}' failed twice and was retried."
           ${{ inputs.command }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -52,13 +52,13 @@ jobs:
         id: cache-nodemodules
         uses: actions/cache@v3
         env:
-          cache-name: cache-node-modules
+          cache-name: cache-node-modules-yarn-globals
         with:
           path: |
             "**/node_modules"
             ${{ steps.yarnGlobalDir.outputs.yarnGlobalDir}}
             ${{ steps.yarnGlobalBin.outputs.yarnGlobalBin}}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn global add sfdx-cli @salesforce/cli
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn install --network-timeout 600000

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -55,11 +55,22 @@ jobs:
       - run: yarn global add sfdx-cli @salesforce/cli
       - run: yarn install --network-timeout 600000
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
-
       - run: yarn compile
-      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || (echo "NUTs attempt 2:" && ${{ inputs.command }}) || (echo "NUTs attempt 3:" && ${{ inputs.command }}) || (echo "NUTs failed!" && exit 1)
-        if: inputs.sfdxExecutablePath != ''
-        env:
-          TESTKIT_EXECUTABLE_PATH: ${{ inputs.sfdxExecutablePath }}
-      - run: (echo "NUTs attempt 1:" && ${{ inputs.command }}) || (echo "NUTs attempt 2:" && ${{ inputs.command }}) || (echo "NUTs attempt 3:" && ${{ inputs.command }}) || (echo "NUTs failed!" && exit 1)
-        if: inputs.sfdxExecutablePath == ''
+      - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
+        if: inputs.sfdxExecutablePath
+      - name: NUTs attempt 1
+        continue-on-error: true
+        id: nut1
+        run: ${{ inputs.command }}
+      - name: NUTs attempt 2
+        continue-on-error: true
+        id: nut2
+        if: steps.nut1.outcome == 'failure'
+        run: |
+          echo "::notice title=NUT Retry::NUT '${{input.command}}' failed and was retried."
+          ${{ inputs.command }}
+      - name: NUTs attempt 3
+        if: steps.nut2.outcome == 'failure'
+        run: |
+          echo "::warning title=NUT Retry 2::NUT '${{input.command}}' failed twice and was retried."
+          ${{ inputs.command }}

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -68,11 +68,3 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - run: yarn test
-  lockfile-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-      - run: |
-          npm install -g lockfile-lint
-          lockfile-lint --path yarn.lock --allowed-hosts npm yarn --validate-https

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -23,7 +23,7 @@ jobs:
           cache-name: cache-node-modules
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn install  --network-timeout 600000
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@yarn-global-install
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -13,7 +13,7 @@ on:
         description: run unit tests on windows
 
 jobs:
-  unit-tests-linux:
+  linux-unit-tests:
     if: inputs.linux
     strategy:
       matrix:
@@ -40,7 +40,7 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - run: yarn test
-  unit-tests-windows:
+  windows-unit-tests:
     if: inputs.windows
     strategy:
       matrix:

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -16,7 +16,17 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: yarn
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
       - run: yarn install  --network-timeout 600000
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - run: yarn test
   lockfile-check:

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@yarn-global-install
+      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@main
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -1,15 +1,53 @@
 on:
   workflow_call:
+    inputs:
+      linux:
+        type: boolean
+        required: false
+        default: true
+        description: run unit tests on linux
+      windows:
+        type: boolean
+        required: false
+        default: true
+        description: run unit tests on windows
 
 jobs:
-  unit-tests:
+  unit-tests-linux:
+    if: inputs.linux
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
         # node_version: [lts/-1, lts/*, latest]
         node_version: [lts/-1, lts/*]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+
+      - run: yarn install  --network-timeout 600000
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+      - run: yarn build
+      - run: yarn test
+  unit-tests-windows:
+    if: inputs.windows
+    strategy:
+      matrix:
+        # node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/-1, lts/*]
+      fail-fast: false
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@yarn-global-install


### PR DESCRIPTION
1. add faster windows cache algorithm per gha guidance https://github.com/actions/cache/blob/main/workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
2. testkit setup retries 2 for all nuts/extNuts
3. lockfile check as a separate workflow
4. caching for node_modules
5. 2 nuts retries
6. ut can optionally run on a single os so we can start linux nuts without waiting on windows ut