### PR TITLE
Split unit tests

### DIFF
--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -3,6 +3,6 @@ on:
 
 jobs:
   linux-unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@ew/split-unit-tests
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@main
   windows-unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@ew/split-unit-tests
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@main

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -1,21 +1,8 @@
 on:
   workflow_call:
-    inputs:
-      linux:
-        type: boolean
-        required: false
-        default: true
-        description: run unit tests on linux
-      windows:
-        type: boolean
-        required: false
-        default: true
-        description: run unit tests on windows
 
 jobs:
   linux-unit-tests:
-    if: inputs.linux
     uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@ew/split-unit-tests
   windows-unit-tests:
-    if: inputs.windows
     uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@ew/split-unit-tests

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -15,56 +15,7 @@ on:
 jobs:
   linux-unit-tests:
     if: inputs.linux
-    strategy:
-      matrix:
-        # node_version: [lts/-1, lts/*, latest]
-        node_version: [lts/-1, lts/*]
-      fail-fast: false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node_version }}
-          cache: yarn
-      - name: Cache node modules
-        id: cache-nodemodules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-
-      - run: yarn install  --network-timeout 600000
-        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
-      - run: yarn build
-      - run: yarn test
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@ew/split-unit-tests
   windows-unit-tests:
     if: inputs.windows
-    strategy:
-      matrix:
-        # node_version: [lts/-1, lts/*, latest]
-        node_version: [lts/-1, lts/*]
-      fail-fast: false
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@main
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node_version }}
-          cache: yarn
-      - name: Cache node modules
-        id: cache-nodemodules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-
-      - run: yarn install  --network-timeout 600000
-        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
-      - run: yarn build
-      - run: yarn test
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@ew/split-unit-tests

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -1,0 +1,30 @@
+on:
+  workflow_call:
+
+jobs:
+  linux-unit-tests:
+    strategy:
+      matrix:
+        # node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/-1, lts/*]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+
+      - run: yarn install  --network-timeout 600000
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+      - run: yarn build
+      - run: yarn test

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -1,0 +1,31 @@
+on:
+  workflow_call:
+
+jobs:
+  linux-unit-tests:
+    strategy:
+      matrix:
+        # node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/-1, lts/*]
+      fail-fast: false
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: salesforcecli/github-workflows/.github/actions/windowsCachePerf@main
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: yarn
+      - name: Cache node modules
+        id: cache-nodemodules
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+
+      - run: yarn install  --network-timeout 600000
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+      - run: yarn build
+      - run: yarn test


### PR DESCRIPTION
Calling the `unitTest.yml` file from a plugin (`test.yml`) with the conditional OSes made the GHA flow cluttered and confusing. I split the two OS unit tests into their own file and kept the base `unitTest` file for backward compatibility. 

**BEFORE**
<img width="1008" alt="Screen Shot 2022-10-28 at 2 42 24 PM" src="https://user-images.githubusercontent.com/1715111/198720802-e0ee457c-25b8-4473-9a73-8ee2be505a83.png">

**AFTER**
<img width="988" alt="Screen Shot 2022-10-28 at 2 47 52 PM" src="https://user-images.githubusercontent.com/1715111/198720834-f1cea790-37a1-4264-9fba-37e02aa64a39.png">
