### PR TITLE
feat: add ability to set different github token for release workflow

### DIFF
--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -7,11 +7,6 @@ on:
         required: false
         default: false
         description: use a prerelease instead of a regular release
-      githubToken:
-        type: string
-        required: false
-        default: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-        description: github token used for repo interactions
 
 jobs:
   release:
@@ -19,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: inputs.githubToken
+          token: ${{ secrets.ALT_GITHUB_TOKEN || secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 
       - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
         id: distTag
@@ -38,14 +33,14 @@ jobs:
         with:
           git-user-name: svc-cli-bot
           git-user-email: svc_cli_bot@salesforce.com
-          github-token: inputs.githubToken
+          github-token: ${{ secrets.ALT_GITHUB_TOKEN || secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           output-file: "false"
           tag-prefix: ""
       - name: Create Github Release
         uses: actions/create-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         env:
-          GITHUB_TOKEN: inputs.githubToken
+          GITHUB_TOKEN: ${{ secrets.ALT_GITHUB_TOKEN || secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -7,6 +7,11 @@ on:
         required: false
         default: false
         description: use a prerelease instead of a regular release
+      githubToken:
+        type: string
+        required: false
+        default: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+        description: github token used for repo interactions
 
 jobs:
   release:
@@ -14,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          token: inputs.githubToken
 
       - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
         id: distTag
@@ -33,14 +38,14 @@ jobs:
         with:
           git-user-name: svc-cli-bot
           git-user-email: svc_cli_bot@salesforce.com
-          github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          github-token: inputs.githubToken
           output-file: "false"
           tag-prefix: ""
       - name: Create Github Release
         uses: actions/create-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: inputs.githubToken
         with:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -7,6 +7,9 @@ on:
         required: false
         default: false
         description: use a prerelease instead of a regular release
+    secrets:
+      ALT_GITHUB_TOKEN:
+        required: false
 
 jobs:
   release:


### PR DESCRIPTION
Added the ALT_GITHUB_TOKEN secret that can optionally be passed to the githubRelease workflow to be used instead of the SVC_CLI_BOT_GITHUB_TOKEN token.  This was needed as a result of using the githubRelease flow in the forcedotcom/schemas repo and will also be used for the apex and templates node library repos. 

I initially tried using an input but b/c the value is a secret in the schemas org or it had to be secret here as well. 