### PR TITLE
Seperate command from echo

### DIFF
--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -26,7 +26,8 @@ jobs:
             echo "Environment not configured for CTC.  Your environment needs SF_CHANGE_CASE_SFDX_AUTH_URL, SF_CHANGE_CASE_TEMPLATE_ID, and SF_CHANGE_CASE_CONFIGURATION_ITEM"
             exit 1
           else
-            echo "::set-output name=ctcResult::$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json | jq -r '.result.id')"
+            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json | jq -r '.result.id')
+            echo "::set-output name=ctcResult::$CTC_RESULT"
           fi
         env:
           SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ secrets.SF_CHANGE_CASE_SFDX_AUTH_URL}}


### PR DESCRIPTION
`ctcOpen` [failed silently](https://github.com/salesforcecli/cli/actions/runs/3698754560/jobs/6265343850), which in turn caused `ctcClose` [to fail](https://github.com/salesforcecli/cli/actions/runs/3698754560/jobs/6265388047) because it didn't have a valid id. From what I can tell, none of these files changed recently. I believe this "passed" because the exit code was swallowed by the `echo`. 

Example:
<img width="368" alt="Screen Shot 2022-12-14 at 3 53 30 PM" src="https://user-images.githubusercontent.com/1715111/207725167-03d6eb20-9703-4112-90b4-b783dc7e7adb.png">
