### PR TITLE
Skip changelog write on prerelease

### DIFF
--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -36,6 +36,7 @@ jobs:
           github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           tag-prefix: ""
           release-count: "0"
+          output-file: ${{ !inputs.prerelease }} # If prerelease, do not write the changelog file
       - name: Create Github Release
         uses: actions/create-release@v1
         if: ${{ steps.changelog.outputs.skipped == 'false' }}


### PR DESCRIPTION
Writing the changelog file on prereleases was causing the Release to be skipped once it was merged into main. 

We will skip changelog writing on prereleases

[@W-12285184@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12285184)