### PR TITLE
Retry ctcOpen and properly exit with 1 to stop build

### DIFF
--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -25,10 +25,34 @@ jobs:
           if [ -z "${SF_CHANGE_CASE_SFDX_AUTH_URL}" ] || [ -z "${SF_CHANGE_CASE_TEMPLATE_ID}" ] || [ -z "${SF_CHANGE_CASE_CONFIGURATION_ITEM}" ] ; then
             echo "Environment not configured for CTC.  Your environment needs SF_CHANGE_CASE_SFDX_AUTH_URL, SF_CHANGE_CASE_TEMPLATE_ID, and SF_CHANGE_CASE_CONFIGURATION_ITEM"
             exit 1
-          else
-            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json | jq -r '.result.id')
-            echo "::set-output name=ctcResult::$CTC_RESULT"
           fi
+
+          ATTEMPT=1
+          MAX=5
+          DELAY=15 # In seconds
+
+          function CREATE_CHANGE_CASE {
+              CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json | jq -r '.result.id')
+
+              if [[ "$CTC_RESULT" == null ]]; then
+                  return 1
+              fi
+          }
+
+          while true; do
+              CREATE_CHANGE_CASE && break || {
+                  if [[ $ATTEMPT -lt $MAX ]]; then
+                      ((ATTEMPT++))
+                      echo "Change Case creation failed - trying again ($ATTEMPT/$MAX)"
+                      sleep $DELAY;
+                  else
+                      "Failed to create a Change Case after $ATTEMPT attempts"
+                      exit 1
+                  fi
+              }
+          done
+
+          echo "::set-output name=ctcResult::$CTC_RESULT"
         env:
           SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ secrets.SF_CHANGE_CASE_SFDX_AUTH_URL}}
           SF_CHANGE_CASE_TEMPLATE_ID: ${{ secrets.SF_CHANGE_CASE_TEMPLATE_ID}}


### PR DESCRIPTION
We have had `ctcOpen` fail often. Most of the time it will work on a retry. This adds retries and will (hopefully) stop the build with exit code 1 if it fails.

Here is an example script that you can test with:
```sh
#! /bin/bash

ATTEMPT=1
MAX=5
DELAY=5 # seconds

function CREATE_CHANGE_CASE {
    FOO=$(echo '{"foo": "bar"}' | jq -r '.baz')

    # UNCOMMENT THIS TO SHOW A PASSING SCENARIO
    # if [[ $ATTEMPT -eq 4 ]]; then
    #     FOO=$(echo '{"foo": "bar"}' | jq -r '.foo')
    # fi

    if [[ "$FOO" == null ]]; then
        return 1
    fi
}

while true; do
    CREATE_CHANGE_CASE && break || {
        if [[ $ATTEMPT -lt $MAX ]]; then
            ((ATTEMPT++))
            echo "Change Case creation failed - trying again ($ATTEMPT/$MAX)"
            sleep $DELAY;
        else
            "Failed to create a Change Case after $ATTEMPT attempts"
            exit 1
        fi
    }
done

echo "FOO IS: $FOO";

```