### PR TITLE
Add ctcOpen action

### DIFF
--- a/.github/actions/ctcOpen/action.yml
+++ b/.github/actions/ctcOpen/action.yml
@@ -1,0 +1,60 @@
+name: ctcOpen
+description: Open a CTC case for a release
+
+outputs:
+  changeCaseId:
+    description: Id for the change case created
+    value: ${{ steps.ctc.outputs.ctcResult }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: lts/*
+        cache: npm
+
+    - run: npm install -g @salesforce/change-case-management --omit=dev
+      shell: bash
+
+    - id: ctc
+      shell: bash
+      run: |
+        if [ -z "${SF_CHANGE_CASE_SFDX_AUTH_URL}" ] || [ -z "${SF_CHANGE_CASE_TEMPLATE_ID}" ] || [ -z "${SF_CHANGE_CASE_CONFIGURATION_ITEM}" ] ; then
+          echo "Environment not configured for CTC.  Your environment needs SF_CHANGE_CASE_SFDX_AUTH_URL, SF_CHANGE_CASE_TEMPLATE_ID, and SF_CHANGE_CASE_CONFIGURATION_ITEM"
+          exit 1
+        fi
+
+        ATTEMPT=1
+        MAX=5
+        DELAY=15 # In seconds
+
+        function CREATE_CHANGE_CASE {
+            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json | jq -r '.result.id')
+
+            if [[ "$CTC_RESULT" == null ]]; then
+                return 1
+            fi
+        }
+
+        while true; do
+            CREATE_CHANGE_CASE && break || {
+                if [[ $ATTEMPT -lt $MAX ]]; then
+                    ((ATTEMPT++))
+                    echo "Change Case creation failed - trying again ($ATTEMPT/$MAX)"
+                    sleep $DELAY;
+                else
+                    "Failed to create a Change Case after $ATTEMPT attempts"
+                    exit 1
+                fi
+            }
+        done
+
+        echo "ctcResult=$CTC_RESULT" >> "$GITHUB_OUTPUT"
+      env:
+        SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ secrets.SF_CHANGE_CASE_SFDX_AUTH_URL}}
+        SF_CHANGE_CASE_TEMPLATE_ID: ${{ secrets.SF_CHANGE_CASE_TEMPLATE_ID}}
+        SF_CHANGE_CASE_CONFIGURATION_ITEM: ${{ secrets.SF_CHANGE_CASE_CONFIGURATION_ITEM}}
+
+    - run: echo "case id is ${{ steps.ctc.outputs.ctcResult }}"
+      shell: bash


### PR DESCRIPTION
[The "optional step" job](https://github.com/iowillhoit/gha-sandbox/blob/main/.github/workflows/needing-an-optional-job-alternate.yml) that I got working will not work when calling a workflow. 
`reusable workflows should be referenced at the top-level 'jobs.*.uses' key, not within steps`
I am going to try moving `ctcOpen` to an action so that I can call it in a step

I will use `runs-on: static-ip-ubuntu-runners` on the Job that will call this ^