### PR TITLE
Retry pack:tarball

### DIFF
--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -34,7 +34,13 @@ jobs:
           node-version: lts/*
           cache: yarn
       - run: yarn install  --network-timeout 600000
-      - run: yarn pack:tarballs
+      - name: pack tarballs
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        with:
+          max_attempts: 3
+          command: yarn pack:tarballs
+          retry_on: error
+          timeout_minutes: 60
       - run: yarn pack:verify
       - run: yarn test:smoke-unix
       - if: inputs.upload


### PR DESCRIPTION
I keep seeing S3 errors during this step, after retrying it eventually passes.
Example: https://github.com/salesforcecli/sfdx-cli/actions/runs/4502666115/jobs/7924813403?pr=1046#step:5:32