### PR TITLE
feat: parameterize nut secrets for reuse outside salesforce gh organization

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -1,5 +1,17 @@
 on:
   workflow_call:
+    secrets:
+      TESTKIT_AUTH_URL:
+        required: false
+      TESTKIT_HUB_USERNAME:
+        required: false
+      TESTKIT_JWT_CLIENT_ID:
+        required: false
+      TESTKIT_JWT_KEY:
+        required: false
+      TESTKIT_HUB_INSTANCE:
+        required: false
+
     inputs:
       # could we get this from pjson?
       packageName:
@@ -60,13 +72,6 @@ on:
 
 jobs:
   external-nut:
-    env:
-      TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL }}
-      TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
-      TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
-      TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
-      TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
-      TESTKIT_SETUP_RETRIES: 2
     name: ${{ inputs.command }}
     runs-on: ${{ inputs.os }}
     steps:
@@ -121,3 +126,10 @@ jobs:
           command: ${{ inputs.command }}
           retry_on: error
           timeout_minutes: 60
+        env:
+          TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL }}
+          TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
+          TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
+          TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
+          TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
+          TESTKIT_SETUP_RETRIES: 2

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -1,5 +1,23 @@
 on:
   workflow_call:
+    secrets:
+      SF_CHANGE_CASE_SFDX_AUTH_URL:
+        description: "SFDX_AUTH_URL for the CTC org. Only useful for the CTC NUTs."
+        required: false
+      ONEGP_TESTKIT_AUTH_URL:
+        description: "SFDX_AUTH_URL for the 1GP org. Only useful for the 1GP NUTs in packaging"
+        required: false
+      TESTKIT_AUTH_URL:
+        required: false
+      TESTKIT_HUB_USERNAME:
+        required: false
+      TESTKIT_JWT_CLIENT_ID:
+        required: false
+      TESTKIT_JWT_KEY:
+        required: false
+      TESTKIT_HUB_INSTANCE:
+        required: false
+
     inputs:
       command:
         required: false
@@ -32,14 +50,6 @@ on:
 
 jobs:
   nut:
-    env:
-      TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL}}
-      TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
-      TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
-      TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
-      TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
-      ONEGP_TESTKIT_AUTH_URL: ${{ secrets.ONEGP_TESTKIT_AUTH_URL }}
-      TESTKIT_SETUP_RETRIES: 2
     name: ${{ inputs.command }}
     runs-on: ${{ inputs.os }}
     steps:
@@ -71,3 +81,12 @@ jobs:
           command: ${{ inputs.command }}
           retry_on: error
           timeout_minutes: 60
+        env:
+          TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL}}
+          TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}
+          TESTKIT_JWT_CLIENT_ID: ${{ secrets.TESTKIT_JWT_CLIENT_ID }}
+          TESTKIT_JWT_KEY: ${{ secrets.TESTKIT_JWT_KEY }}
+          TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
+          ONEGP_TESTKIT_AUTH_URL: ${{ secrets.ONEGP_TESTKIT_AUTH_URL }}
+          SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ secrets.SF_CHANGE_CASE_SFDX_AUTH_URL }}
+          TESTKIT_SETUP_RETRIES: 2

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -4,6 +4,12 @@ on:
       SF_CHANGE_CASE_SFDX_AUTH_URL:
         description: "SFDX_AUTH_URL for the CTC org. Only useful for the CTC NUTs."
         required: false
+      SF_CHANGE_CASE_TEMPLATE_ID:
+        required: false
+        description: "Template ID for the CTC org. Only useful for the CTC NUTs."
+      SF_CHANGE_CASE_CONFIGURATION_ITEM:
+        required: false
+        description: "Configuration Item for the CTC org. Only useful for the CTC NUTs."
       ONEGP_TESTKIT_AUTH_URL:
         description: "SFDX_AUTH_URL for the 1GP org. Only useful for the 1GP NUTs in packaging"
         required: false
@@ -89,4 +95,6 @@ jobs:
           TESTKIT_HUB_INSTANCE: ${{ secrets.TESTKIT_HUB_INSTANCE }}
           ONEGP_TESTKIT_AUTH_URL: ${{ secrets.ONEGP_TESTKIT_AUTH_URL }}
           SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ secrets.SF_CHANGE_CASE_SFDX_AUTH_URL }}
+          SF_CHANGE_CASE_TEMPLATE_ID: ${{ secrets.SF_CHANGE_CASE_TEMPLATE_ID}}
+          SF_CHANGE_CASE_CONFIGURATION_ITEM: ${{ secrets.SF_CHANGE_CASE_CONFIGURATION_ITEM}}
           TESTKIT_SETUP_RETRIES: 2


### PR DESCRIPTION
all nut secrets are params so they can be used across gh organization boundaries

[@W-12083615@](https://gus.lightning.force.com/a07EE00001DTeIGYA1)

proof it works on existing nuts (secrets:inherit)
https://github.com/salesforcecli/plugin-user/actions/runs/4601960461

proof it works with secrets passed in explicitly
https://github.com/forcedotcom/change-case-management/actions/runs/4600554348/jobs/8127337773 