### PR TITLE
Sm/preserve perf

### DIFF
--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -20,7 +20,7 @@ jobs:
       - name: build docs
         # perf tests also store results on docs/gh-page, so we need to not delete those
         run: |
-          find . -not -path '*perf*' -delete
+          find ./docs -not -path './docs/perf*' -delete
           git worktree prune
           git fetch origin gh-pages:gh-pages
           git worktree add docs gh-pages

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
       - name: build docs
         run: |
-          rm -rf docs
+          find . -not -path '*perf-*' -delete
           git worktree prune
           git fetch origin gh-pages:gh-pages
           git worktree add docs gh-pages

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -18,8 +18,9 @@ jobs:
       - run: yarn install  --network-timeout 600000
       - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
       - name: build docs
+        # perf tests also store results on docs/gh-page, so we need to not delete those
         run: |
-          find . -not -path '*perf-*' -delete
+          find . -not -path '*perf*' -delete
           git worktree prune
           git fetch origin gh-pages:gh-pages
           git worktree add docs gh-pages


### PR DESCRIPTION
preserve perf test results when regenerating docs.

this needs to not delete that dir, but also not cause git conflicts.  I don't know enough about worktrees to be sure this is going to work.