### PR TITLE
Sm/external-nut-deps

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -58,7 +58,7 @@ on:
         default: 'echo "no preExternalBuildCommands passed"'
       preSwapCommands:
         required: false
-        description: "commands to run any changes happen.  For example, changes that modify the lockfile like yarn add or remove need to happen before the action manually swaps the dependency under test"
+        description: "commands to run before ANY modifications happen.  For example, changes that modify the lockfile like yarn add or remove need to happen before the action manually swaps the dependency under test"
         type: string
         default: 'echo "no preExternalBuildCommands passed"'
       useCache:

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -56,6 +56,11 @@ on:
         description: "commands to run before the build of the external repo...for example, to delete known module conflicts"
         type: string
         default: 'echo "no preExternalBuildCommands passed"'
+      preSwapCommands:
+        required: false
+        description: "commands to run any changes happen.  For example, changes that modify the lockfile like yarn add or remove need to happen before the action manually swaps the dependency under test"
+        type: string
+        default: 'echo "no preExternalBuildCommands passed"'
       useCache:
         required: false
         type: boolean

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -60,7 +60,7 @@ on:
         required: false
         description: "commands to run before ANY modifications happen.  For example, changes that modify the lockfile like yarn add or remove need to happen before the action manually swaps the dependency under test"
         type: string
-        default: 'echo "no preExternalBuildCommands passed"'
+        default: 'echo "no preSwapCommands passed"'
       useCache:
         required: false
         type: boolean

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -109,6 +109,9 @@ jobs:
           key: ${{ runner.os }}-externalNuts-${{ env.cache-name }}-${{ inputs.externalProjectGitUrl}}-${{ inputs.branch}}-${{ github.sha }}
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+      - run: ${{inputs.preSwapCommands}}
+        if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
+
       - name: swap this dependency for the version on this branch
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
         run: |


### PR DESCRIPTION
oh, you need to modify some dep before doing all the other things?  One more place to insert arbitrary code.

[primary use case: doing things that would change yarn lock (yarn add/remove) so it doesn't hose the dirty swap we do in `swap this dependency for the version on this branch`

qa'd here: https://github.com/forcedotcom/source-tracking/actions/runs/4671550105