### PR TITLE
Secrets-input

### DIFF
--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -1,6 +1,10 @@
 name: tag and github release
 on:
   workflow_call:
+    secrets:
+      SVC_CLI_BOT_GITHUB_TOKEN:
+        description: a github PAT with repo access
+
     inputs:
       prerelease:
         type: boolean

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -1,5 +1,13 @@
 on:
   workflow_call:
+    secrets:
+      NPM_TOKEN:
+        description: npm token
+      AWS_ACCESS_KEY_ID:
+        description: aws access key id.  Only requied if sign = true
+      AWS_SECRET_ACCESS_KEY:
+        description: aws secret access key.  Only requied if sign = true
+
     inputs:
       tag:
         required: false


### PR DESCRIPTION
allow secrets to be passed in for the release/publish actions.

for sharing actions across enterprise boundaries (ie, oclif)

usage as qa:
https://github.com/oclif/oclif/actions/runs/4855684156/jobs/8654486421#step:11:113