### PR TITLE
chore: disable weekend dev-scripts updates

### DIFF
--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -4,6 +4,8 @@ on:
 jobs:
   # what is the RC version, numerically?
   compareVersions:
+    # skip from all places it's called
+    if: false
     outputs:
       shouldUpdate: ${{ !endsWith(steps.packageVersion.outputs.prop, steps.version-info.outputs.version) }}
 


### PR DESCRIPTION
I'd like to prevent devScripts update from running while the libraries are in transition for es2021.