### PR TITLE
chore: allow setting of node-version

### DIFF
--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -13,7 +13,11 @@ on:
         type: string
         required: true
         description: channel that the uploaded tarballs get promoted to
-
+      nodeVersion:
+        type: string
+        required: true
+        default: lts/*
+        description: node version to use for the tarball build
 jobs:
   macos:
     env:
@@ -26,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: ${{ inputs.nodeVersion }}
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       # todo: download the macos tarball and pass that to the oclif pack:macos command

--- a/.github/workflows/packUploadWindows.yml
+++ b/.github/workflows/packUploadWindows.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: true
         description: channel that the uploaded tarballs get promoted to
+      nodeVersion:
+        type: string
+        required: true
+        default: lts/*
+        description: node version to use for the tarball build
 
 jobs:
   win:
@@ -29,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: ${{ inputs.nodeVersion }}
           cache: yarn
       - run: |
           sudo apt-get update

--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -17,6 +17,11 @@ on:
         type: string
         required: false
         description: channel that the uploaded tarballs get promoted to
+      nodeVersion:
+        type: string
+        required: true
+        default: lts/*
+        description: node version to use for the tarball build
 
 jobs:
   tarballs:
@@ -32,7 +37,7 @@ jobs:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: ${{ inputs.nodeVersion }}
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - name: pack tarballs


### PR DESCRIPTION
allows a CLI building tarballs/installers to set its nodeVersion.  defaults to lts when not set