### PR TITLE
fix: install @salesforce/cli@beta

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -87,7 +87,7 @@ jobs:
         name: cli install
         with:
           max_attempts: ${{ inputs.attempts }}
-          command: npm install @salesforce/cli@^2 shx yarn-deduplicate --omit=dev
+          command: npm install @salesforce/cli@beta shx yarn-deduplicate --omit=dev
           timeout_minutes: 20
       - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         name: git clone

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -77,7 +77,7 @@ jobs:
         name: add CLIs as global dependencies
         with:
           max_attempts: ${{ inputs.retries }}
-          command: yarn global add @salesforce/cli@^2
+          command: yarn global add @salesforce/cli@beta
           timeout_minutes: 60
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
[skip-validate-pr]

installs beta channel because 
`@^2` won't resolve `2.0.0-beta.47` causing this failure 

`error Couldn't find any versions for "@salesforce/cli" that matches "^2"`
https://github.com/salesforcecli/plugin-apex/actions/runs/5149961026/jobs/9273588342?pr=143