### PR TITLE
feat: test on latest node (currently 20)

### DIFF
--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -5,8 +5,7 @@ jobs:
   linux-unit-tests:
     strategy:
       matrix:
-        # node_version: [lts/-1, lts/*, latest]
-        node_version: [lts/-1, lts/*]
+        node_version: [lts/-1, lts/*, latest]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -5,8 +5,7 @@ jobs:
   windows-unit-tests:
     strategy:
       matrix:
-        # node_version: [lts/-1, lts/*, latest]
-        node_version: [lts/-1, lts/*]
+        node_version: [lts/-1, lts/*, latest]
       fail-fast: false
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
run UT on node 20.
this requires newer versions of eslint-jsdoc, but that should be everywhere now because of dev scripts 