### PR TITLE
Ew/tripss

### DIFF
--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -21,7 +21,7 @@ runs:
     - run: echo "found version ${{ steps.packageVersion.outputs.prop  }}"
       shell: bash
 
-    - uses: booxmedialtd/ws-action-parse-semver@e4a833cf5d612066a210bd9b62d1c3b20be3b325
+    - uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3
       id: versionSuffix
       with:
         input_string: ${{ steps.packageVersion.outputs.prop }}

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
+    - uses: notiz-dev/github-action-json-property@7a701887f4b568b23eb7b78bb0fc49aaeb1b68d3
       id: packageVersion
       with:
         path: "package.json"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,66 @@
+name: create-github-release
+on:
+  workflow_call:
+    secrets:
+      SVC_CLI_BOT_GITHUB_TOKEN:
+        description: a github PAT with repo access
+
+    inputs:
+      prerelease:
+        type: string
+        description: "Name to use for the prerelease: beta, dev, etc."
+      skip-on-empty:
+        type: boolean
+        default: true
+        description: "Should release be skipped if there are no semantic commits?"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+
+      - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
+        id: distTag
+
+      - name: Determine prerelease name
+        id: prereleaseTag
+        run: |
+          if [ -n "${{ steps.distTag.outputs.tag }}" ]; then
+            echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"
+            echo "tag=${{ steps.distTag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -n "${{ inputs.prerelease }}" ]; then
+            echo "Prerelease input passed in, using: ${{ inputs.prerelease }}"
+            echo "tag=${{ inputs.prerelease }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+        with:
+          git-user-name: svc-cli-bot
+          git-user-email: svc_cli_bot@salesforce.com
+          github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          tag-prefix: ""
+          # Setting 'release-count' to 0 will keep ALL releases in the change log file (no pruning)
+          release-count: "0"
+          skip-on-empty: ${{ inputs.skip-on-empty }}
+          pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
+          pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
+          # ternary-ish: https://github.com/actions/runner/issues/409#issuecomment-752775072
+          output-file: ${{ steps.prereleaseTag.outputs.tag && 'false' || 'CHANGELOG.md' }} # If prerelease, do not write the changelog file
+
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          prerelease: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -34,9 +34,7 @@ jobs:
           if [ -n "${{ steps.distTag.outputs.tag }}" ]; then
             echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"
             echo "tag=${{ steps.distTag.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ -n "${{ inputs.prerelease }}" ]; then
+          elif [ -n "${{ inputs.prerelease }}" ]; then
             echo "Prerelease input passed in, using: ${{ inputs.prerelease }}"
             echo "tag=${{ inputs.prerelease }}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Determine prerelease name
         id: prereleaseTag
+        # Only run this step if the ref is not main
+        # This will allow us to merge a prerelease PR into main and have it release as a normal release
+        if: ${{ github.ref_name != 'main' }}
         run: |
           if [ -n "${{ steps.distTag.outputs.tag }}" ]; then
             echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -31,16 +31,12 @@ jobs:
         # This will allow us to merge a prerelease PR into main and have it release as a normal release
         if: ${{ github.ref_name != 'main' }}
         run: |
-        elif [ -n "${{ inputs.prerelease }}" ]; then
-        echo "Prerelease input passed in, using: ${{ inputs.prerelease }}"
-        echo "tag=${{ inputs.prerelease }}" >> "$GITHUB_OUTPUT"
-      fi
-          if [ -n "${{ steps.distTag.outputs.tag }}" ]; then
-            echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"
-            echo "tag=${{ steps.distTag.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          elif [ -n "${{ inputs.prerelease }}" ]; then
+          if [ -n "${{ inputs.prerelease }}" ]; then
             echo "Prerelease input passed in, using: ${{ inputs.prerelease }}"
             echo "tag=${{ inputs.prerelease }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ steps.distTag.outputs.tag }}" ]; then
+            echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"
+            echo "tag=${{ steps.distTag.outputs.tag }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Conventional Changelog Action

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -25,11 +25,18 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
         id: distTag
 
+      - name: Validate prerelease
+        if: github.ref_name == 'main' && inputs.prerelease
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed('Do not create a prerelease on "main". You can create a prerelease on a branch and when it is merged it will create a non-prerelease Release. For example: 1.0.1-beta.2 will release as 1.0.1 when merged into main.')
+
       - name: Determine prerelease name
         id: prereleaseTag
         # Only run this step if the ref is not main
         # This will allow us to merge a prerelease PR into main and have it release as a normal release
-        if: ${{ github.ref_name != 'main' }}
+        if: github.ref_name != 'main'
         run: |
           if [ -n "${{ inputs.prerelease }}" ]; then
             echo "Prerelease input passed in, using: ${{ inputs.prerelease }}"

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -44,6 +44,9 @@ jobs:
           elif [ -n "${{ steps.distTag.outputs.tag }}" ]; then
             echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"
             echo "tag=${{ steps.distTag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          elif [[ ${{ github.ref_name }} =~ ^prerelease/.* ]]; then
+            echo "Prerelease branch found but no prerelease tag, using default: dev"
+            echo "tag=dev" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Conventional Changelog Action

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -31,6 +31,10 @@ jobs:
         # This will allow us to merge a prerelease PR into main and have it release as a normal release
         if: ${{ github.ref_name != 'main' }}
         run: |
+        elif [ -n "${{ inputs.prerelease }}" ]; then
+        echo "Prerelease input passed in, using: ${{ inputs.prerelease }}"
+        echo "tag=${{ inputs.prerelease }}" >> "$GITHUB_OUTPUT"
+      fi
           if [ -n "${{ steps.distTag.outputs.tag }}" ]; then
             echo "Prerelease tag found in package.json, using: ${{ steps.distTag.outputs.tag }}"
             echo "tag=${{ steps.distTag.outputs.tag }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -17,7 +17,7 @@ jobs:
           version: latest
           npmPackage: "@salesforce/dev-scripts"
       - run: echo "dev scripts latest is ${{ steps.version-info.outputs.version }}"
-      - uses: notiz-dev/github-action-json-property@2192e246737701f108a4571462b76c75e7376216
+      - uses: notiz-dev/github-action-json-property@7a701887f4b568b23eb7b78bb0fc49aaeb1b68d3
         id: packageVersion
         with:
           path: "package.json"

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -33,13 +33,16 @@ jobs:
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: salesforcecli/conventional-changelog-action@prereleases
+        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
           git-user-name: svc-cli-bot
           git-user-email: svc_cli_bot@salesforce.com
           github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           tag-prefix: ""
+          # Setting 'release-count' to 0 will keep ALL releases in the change log (no pruning)
           release-count: "0"
+          pre-release: ${{ inputs.prerelease }}
+          pre-release-identifier: ${{ steps.distTag.outputs.tag }}
           # ternary-ish: https://github.com/actions/runner/issues/409#issuecomment-752775072
           output-file: ${{ inputs.prerelease && 'false' || 'CHANGELOG.md' }} # If prerelease, do not write the changelog file
       - name: Create Github Release


### PR DESCRIPTION
Now that `TriPSs/conventional-changelog-action` supports prereleases, we are moving away from our fork.

This PR also adds support for the `create-github-release` workflow to be used for both manual and automated releases. Currently, each of our repos have a `manual-release.yml` that duplicates most of the logic in `githubRelease.yml`. Having a shared workflow will make updating that shared logic much easier in the future. See an example of the new shared workflow that will be updated in all repos here: https://github.com/salesforcecli/testPackageRelease/blob/main/.github/workflows/create-github-release.yml

Adds enhanced support for prereleases, see testing scenarios below

ALSO, updates a couple external actions that were using the deprecated `set-output` commands. I pulled both actions locally and reviewed the code for mischief. Code looked good, packages are legit, and built files were not tampered with. 

Migration plan:
- Since `create-github-release` is a new workflow file, we can migrate our plugins over one by one
- After all repos have been moved, remove the `githubRelease.yml` file
- Announce in `#platform-cli` and `#platform-dev-tools` that the old file has been removed with instructions to migrate.

Testing Scenarios for releases

- Manual prerelease of a PR
  - PR https://github.com/salesforcecli/testPackageRelease/pull/10
  - Prerelease: https://github.com/salesforcecli/testPackageRelease/actions/runs/5424197922
  - Publish: https://github.com/salesforcecli/testPackageRelease/actions/runs/5424201113
  - Minor release after merge: https://github.com/salesforcecli/testPackageRelease/actions/runs/5424241187/jobs/9863320851#step:6:191
- Do not allow creating a prerelease on `main`
  - Action: https://github.com/salesforcecli/testPackageRelease/actions/runs/5465870917/jobs/9949961315#step:4:10
- Prerelease branches still work
  - BONUS, now we have a default prerelease tag of `dev` if you forget to set one. 
    - PR without tag set: https://github.com/salesforcecli/testPackageRelease/pull/11
    - Action default: https://github.com/salesforcecli/testPackageRelease/actions/runs/5466128855/jobs/9950597498#step:5:14
  - Dev release created https://github.com/salesforcecli/testPackageRelease/actions/runs/5466132149 
  - Random push to `prerelease/**` branch https://github.com/salesforcecli/testPackageRelease/pull/11/commits/dcebf2df630bc8b99024e18097dd6d53a9a5ac65
  - A new automatic `dev` release: https://github.com/salesforcecli/testPackageRelease/actions/runs/5466196500
  - PR was merged...
  - Release happened based on Semantic commits (`1.47.0`)! https://github.com/salesforcecli/testPackageRelease/actions/runs/5466298231
- Testing that we can still manually release from `main` if we forgot semantic commits
  - Just a chore PR https://github.com/salesforcecli/testPackageRelease/pull/12
  - Release was skipped https://github.com/salesforcecli/testPackageRelease/actions/runs/5467880098/jobs/9954762564#step:6:190
  - skip-on-empty was honored https://github.com/salesforcecli/testPackageRelease/actions/runs/5467899562/jobs/9954809232#step:6:198
  - Release happened: https://github.com/salesforcecli/testPackageRelease/actions/runs/5467902203