### PR TITLE
feat: use sf v2 for nuts after GA

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -87,7 +87,7 @@ jobs:
         name: cli install
         with:
           max_attempts: ${{ inputs.attempts }}
-          command: npm install -g @salesforce/cli@beta shx yarn-deduplicate --omit=dev
+          command: npm install -g @salesforce/cli shx yarn-deduplicate --omit=dev
           timeout_minutes: 20
       - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         name: git clone

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -77,7 +77,7 @@ jobs:
         name: add CLIs as global dependencies
         with:
           max_attempts: ${{ inputs.retries }}
-          command: yarn global add @salesforce/cli@beta
+          command: yarn global add @salesforce/cli
           timeout_minutes: 60
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
> merge after sf v2 GA 

stops installing the `beta` for nuts/extNuts