### PR TITLE
chore: use sf, not sfdx for npm publish

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -88,9 +88,7 @@ jobs:
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - run: yarn build
-      # why do we need the CLI?  used to get plugin-trust to verify signing
-      # https://github.com/salesforcecli/plugin-release-management/blob/7af2a65a07a42800c364478a2a85eafdc97b1c7d/src/commands/npm/package/release.ts#L151-L152
-      - run: npm install -g @salesforce/cli @salesforce/plugin-release-management --omit=dev
+      - run: npm install -g @salesforce/plugin-release-management
 
       # when dryrun is true: publish with --dryrun flag
       - if: ${{ inputs.dryrun && !inputs.prerelease }}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -88,7 +88,9 @@ jobs:
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - run: yarn build
-      - run: npm install sfdx-cli -g @salesforce/plugin-release-management --omit=dev
+      # why do we need the CLI?  used to get plugin-trust to verify signing
+      # https://github.com/salesforcecli/plugin-release-management/blob/7af2a65a07a42800c364478a2a85eafdc97b1c7d/src/commands/npm/package/release.ts#L151-L152
+      - run: npm install -g @salesforce/cli @salesforce/plugin-release-management --omit=dev
 
       # when dryrun is true: publish with --dryrun flag
       - if: ${{ inputs.dryrun && !inputs.prerelease }}


### PR DESCRIPTION
it *might* be possible to do this better (install plugin-trust and call it, or remove the --omit-dev to get all the deps from PRM, which should include plugin-trust, and then use `./bin/dev` to call that command) so we avoid installing the entire CLI

proof of work 
https://github.com/salesforcecli/testPackageRelease/actions/runs/5558708048/jobs/10154124756