### PR TITLE
Add oclif readme command

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -53,7 +53,7 @@ jobs:
             echo "tag=dev" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Get version for oclif readme
+      - name: Get the next version for oclif readme
         id: next-version
         if: ${{ inputs.generate-readme }}
         uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
@@ -68,12 +68,6 @@ jobs:
           pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
           output-file: "false" # No changelog file
 
-      - name: Before git commands
-        if: ${{ inputs.generate-readme }}
-        run: |
-          git status
-          git diff
-
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}
         run: |
@@ -82,12 +76,6 @@ jobs:
           OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
           # oclif readme has the "v" tag prefix hardcoded, this will replace it with what is in the package.json (v or not)
           sed -i "s|/blob/v${{ steps.next-version.outputs.tag }}|/blob/${{ steps.next-version.outputs.tag }}|g" README.md
-
-      - name: After git commands
-        if: ${{ inputs.generate-readme }}
-        run: |
-          git status
-          git diff
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         default: true
         description: "Should release be skipped if there are no semantic commits?"
+      generate-readme:
+        type: boolean
+        default: true
+        description: "Generate oclif readme"
 
 jobs:
   release:
@@ -48,6 +52,29 @@ jobs:
             echo "Prerelease branch found but no prerelease tag, using default: dev"
             echo "tag=dev" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Get version for oclif readme
+        id: next-version
+        if: ${{ inputs.generate-readme }}
+        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+        with:
+          tag-prefix: ""
+          skip-version-file: true # Do not update the version in the package.json
+          skip-commit: true # Do not commit the version bump
+          git-push: false # Do not push to Github
+          skip-tag: true # Do not tag release
+          skip-on-empty: ${{ inputs.skip-on-empty }}
+          pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
+          pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
+          output-file: "false" # No changelog file
+
+      - name: Temp git diff
+        if: ${{ inputs.generate-readme }}
+        run: git diff --no-pager
+
+      - name: Generate oclif readme
+        if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}
+        run: OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
           tag-prefix: ""
-          skip-version-file: true # Do not update the version in the package.json
+          # skip-version-file: true # Do not update the version in the package.json
           skip-commit: true # Do not commit the version bump
           git-push: false # Do not push to Github
           skip-tag: true # Do not tag release

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -73,9 +73,11 @@ jobs:
         run: |
           yarn install
           yarn compile
-          OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
-          # oclif readme has the "v" tag prefix hardcoded, this will replace it with what is in the package.json (v or not)
-          sed -i "s|/blob/v${{ steps.next-version.outputs.tag }}|/blob/${{ steps.next-version.outputs.tag }}|g" README.md
+          yarn oclif readme \
+            --no-aliases \
+            --version ${{ steps.next-version.outputs.tag }} \
+            --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>" \
+            || echo "::warning::'oclif readme' failed. Check the logs."
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -68,7 +68,7 @@ jobs:
           pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
           output-file: "false" # No changelog file
 
-      - name: Temp git commands
+      - name: Before git commands
         if: ${{ inputs.generate-readme }}
         run: |
           git status
@@ -77,8 +77,15 @@ jobs:
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}
         run: |
+          yarn install
           yarn compile
           OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
+
+      - name: After git commands
+        if: ${{ inputs.generate-readme }}
+        run: |
+          git status
+          git diff
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -68,13 +68,17 @@ jobs:
           pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
           output-file: "false" # No changelog file
 
-      - name: Temp git diff
+      - name: Temp git commands
         if: ${{ inputs.generate-readme }}
-        run: git diff
+        run: |
+          git status
+          git diff
 
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}
-        run: OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
+        run: |
+          yarn compile
+          OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Temp git diff
         if: ${{ inputs.generate-readme }}
-        run: git diff --no-pager
+        run: git diff
 
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
           tag-prefix: ""
-          # skip-version-file: true # Do not update the version in the package.json
+          skip-version-file: true # Do not update the version in the package.json
           skip-commit: true # Do not commit the version bump
           git-push: false # Do not push to Github
           skip-tag: true # Do not tag release
@@ -80,6 +80,8 @@ jobs:
           yarn install
           yarn compile
           OCLIF_NEXT_VERSION=${{ steps.next-version.outputs.tag }} npx oclif readme --no-aliases
+          # oclif readme has the "v" tag prefix hardcoded, this will replace it with what is in the package.json (v or not)
+          sed -i "s|/blob/v${{ steps.next-version.outputs.tag }}|/blob/${{ steps.next-version.outputs.tag }}|g" README.md
 
       - name: After git commands
         if: ${{ inputs.generate-readme }}


### PR DESCRIPTION
Adds `oclif readme` to the `create-github-release` step. 

We use [TriPSs/conventional-changelog-action](https://github.com/TriPSs/conventional-changelog-action) to bump versions and build changelogs. We can run this without any changes/commits/pushes and just get next the "next version" in the output. We then can pass that to `oclif readme` with `OCLIF_NEXT_VERSION`. 

Then we run the conventional-changelog-action again to generate and commit everything (including the readme changes)

Notes:
- I remove the `v` in the [source links](https://github.com/oclif/oclif/blob/main/src/commands/readme.ts#L206) using `sed`. We could make a flag for `oclif readme` if we wanted to 🤷 
- We discussed adding a `"readme": "oclif readme"` script to the `package.json` and adding that to wireit's `build` but we would have to update every single repo. 
- TripPSs does allow you to add a `pre-commit` scripts. Unfortunately it has to be a javascript file so we would also need to add a script to every repo.

Proof of this working: 
https://github.com/salesforcecli/plugin-info/actions/runs/6151426819/job/16691447475
Note the `Before git commands` and `After git commands` steps that I used to confirm changes.

[@W-13887925@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13887925)