### PR TITLE
feat: remove lts/-1 from test matrix

### DIFF
--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -5,7 +5,7 @@ jobs:
   linux-unit-tests:
     strategy:
       matrix:
-        node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/*, latest]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -5,7 +5,7 @@ jobs:
   windows-unit-tests:
     strategy:
       matrix:
-        node_version: [lts/-1, lts/*, latest]
+        node_version: [lts/*, latest]
       fail-fast: false
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
Drop `lts/-1` from unit tests since we won't be supporting node 16 going forward

[skip-validate-pr]