### PR TITLE
chore: use yarn tsc

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}
         run: |
           yarn install
-          yarn compile
+          yarn tsc
           yarn oclif readme \
             --no-aliases \
             --version ${{ steps.next-version.outputs.tag }} \


### PR DESCRIPTION
Use `yarn tsc` before `oclif readme` since oclif plugins don't have a `compile` script

[skip-validate-pr]