### PR TITLE
Continue if wireit cache fails

### DIFF
--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: yarn
       - uses: google/wireit@setup-github-actions-caching/v1
+        continue-on-error: true
       - name: Cache node modules
         id: cache-nodemodules
         uses: actions/cache@v3
@@ -27,6 +28,11 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
-      - run: yarn test
+      - name: yarn test
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        with:
+          max_attempts: 2
+          command: yarn test
+          timeout_minutes: 60
         env:
           SF_DISABLE_TELEMETRY: true

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: google/wireit@setup-github-actions-caching/v1
+        continue-on-error: true
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
@@ -27,11 +28,11 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        env:
-          SF_DISABLE_TELEMETRY: true
-        name: yarn test
+      - name: yarn test
+        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         with:
           max_attempts: 2
           command: yarn test
           timeout_minutes: 60
+        env:
+          SF_DISABLE_TELEMETRY: true


### PR DESCRIPTION
The `wireit` cache can sometimes fail ([example](https://github.com/salesforcecli/plugin-dev/actions/runs/6372109495/job/17294641884#step:8:15)). This PR will continue on with unit tests if the wireit cache setup fails. Also adds retries for linux tests.

Wireit Issue to handle this better: https://github.com/google/wireit/issues/641
Wireit PR where they added some connection retry logic: https://github.com/google/wireit/pull/510/files

[@W-14221405@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14221405)