### PR TITLE
feat: add ignoreScript options to externalNut

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -74,6 +74,11 @@ on:
         description: "branch to clone from the repo.  Defaults to 'main'"
         type: string
         default: "main"
+      ignoreScripts:
+        required: false
+        description: "if true, will run yarn install --ignore-scripts when building package in node_modules"
+        type: boolean
+        default: false
 
 jobs:
   external-nut:
@@ -123,7 +128,7 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
         working-directory: node_modules/${{ inputs.packageName }}
         run: |
-          yarn install  --network-timeout 600000
+          yarn install  --network-timeout 600000 ${{ inputs.ignoreScripts && '--ignore-scripts' }}
           ${{ inputs.preBuildCommands }}
           yarn compile
           ${{ inputs.postBuildCommands }}

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -128,7 +128,7 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
         working-directory: node_modules/${{ inputs.packageName }}
         run: |
-          yarn install  --network-timeout 600000 ${{ inputs.ignoreScripts && '--ignore-scripts' }}
+          yarn install  --network-timeout 600000 ${{ inputs.ignoreScripts && '--ignore-scripts' || '' }}
           ${{ inputs.preBuildCommands }}
           yarn compile
           ${{ inputs.postBuildCommands }}


### PR DESCRIPTION
Adds `ignoreScript` option to `externalNut` to pass in `--ignore-scripts` to the yarn install that is run inside of node_modules. See it working here: https://github.com/oclif/core/actions/runs/6395984185/job/17360979081

[skip-validate-pr]