### PR TITLE
Ew/oclif readme check

### DIFF
--- a/.github/actions/generateOclifReadme/action.yml
+++ b/.github/actions/generateOclifReadme/action.yml
@@ -1,0 +1,49 @@
+name: generate-oclif-readme
+description: Generate oclif readme if it is an oclif plugin
+
+inputs:
+  skip-on-empty:
+    description: Should release be skipped if there are no semantic commits?
+    required: true
+  pre-release:
+    description: Is this release will be a prerelease?
+    required: true
+  pre-release-identifier:
+    description: The name of the prerelease channel (e.g. dev, beta)
+
+runs:
+  using: composite
+  steps:
+    # First we check to see if this is an oclif plugin
+    # If it is not, we will skip readme generation
+    - name: Check that oclif config exists
+      id: is-oclif-plugin
+      shell: bash
+      run: echo "bool=$(jq 'has("oclif")' package.json)" >> "$GITHUB_OUTPUT"
+
+    - name: Get the next version for oclif readme
+      id: next-version
+      if: ${{ steps.is-oclif-plugin.outputs.bool == 'true' }}
+      uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+      with:
+        tag-prefix: ""
+        skip-version-file: true # Do not update the version in the package.json
+        skip-commit: true # Do not commit the version bump
+        git-push: false # Do not push to Github
+        skip-tag: true # Do not tag release
+        skip-on-empty: ${{ inputs.skip-on-empty }}
+        pre-release: ${{ inputs.pre-release }}
+        pre-release-identifier: ${{ inputs.pre-release-identifier }}
+        output-file: "false" # No changelog file
+
+    - name: Generate oclif readme
+      if: ${{ steps.is-oclif-plugin.outputs.bool == 'true' && steps.next-version.outputs.skipped == 'false' }}
+      shell: bash
+      run: |
+        yarn install
+        yarn tsc
+        yarn oclif readme \
+          --no-aliases \
+          --version ${{ steps.next-version.outputs.tag }} \
+          --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>" \
+          || echo "::warning::'oclif readme' failed. Check the logs."

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -53,31 +53,13 @@ jobs:
             echo "tag=dev" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Get the next version for oclif readme
-        id: next-version
+      - name: Generate oclif readme
         if: ${{ inputs.generate-readme }}
-        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@main
         with:
-          tag-prefix: ""
-          skip-version-file: true # Do not update the version in the package.json
-          skip-commit: true # Do not commit the version bump
-          git-push: false # Do not push to Github
-          skip-tag: true # Do not tag release
           skip-on-empty: ${{ inputs.skip-on-empty }}
           pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
           pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
-          output-file: "false" # No changelog file
-
-      - name: Generate oclif readme
-        if: ${{ inputs.generate-readme && steps.next-version.outputs.skipped == 'false' }}
-        run: |
-          yarn install
-          yarn tsc
-          yarn oclif readme \
-            --no-aliases \
-            --version ${{ steps.next-version.outputs.tag }} \
-            --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>" \
-            || echo "::warning::'oclif readme' failed. Check the logs."
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme }}
-        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@main
+        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@ew/oclif-readme-check
         with:
           skip-on-empty: ${{ inputs.skip-on-empty }}
           pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}


### PR DESCRIPTION
Adds a check for the `oclif` object in the `package.json` before creating a `oclif readme`
Moves oclif readme steps to its own action

Example of this generating the readme:
- https://github.com/salesforcecli/plugin-info/pull/543/files
- https://github.com/salesforcecli/plugin-info/actions/runs/6550928368/job/17791052421#step:6:194

Example of generation being skipped:
- https://github.com/forcedotcom/dev-scripts/actions/runs/6551331903/job/17792288314