### PR TITLE
feat: run oclif manifest before nuts

### DIFF
--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn compile
+      - run: yarn oclif manifest
       - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
         if: inputs.sfdxExecutablePath
       - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd


### PR DESCRIPTION
Run `yarn oclif manifest` before running NUTs so that each execution of `bin/run.js` can bypass manifest creation at runtime

@W-14390800@