### PR TITLE
Retry wrapper and determine node versions

### DIFF
--- a/.github/actions/ctcOpen/action.yml
+++ b/.github/actions/ctcOpen/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Open CTC case
       id: ctc
-      uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+      uses: salesforcecli/github-workflows/.github/actions/retry@main
       with:
         max_attempts: 5
         command: |

--- a/.github/actions/ctcOpen/action.yml
+++ b/.github/actions/ctcOpen/action.yml
@@ -37,11 +37,9 @@ runs:
 
     - name: Open CTC case
       id: ctc
-      uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
       with:
         max_attempts: 5
-        retry_wait_seconds: 60
-        timeout_minutes: 60
         command: |
           CTC_RESULT=$(sfchangecase create --location ${{ github.repositoryUrl }} --release ${{ github.repository }}.$(date +%F) --json)
 

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -28,9 +28,15 @@ runs:
 
         {
         echo 'nodeVersions<<EOF'
-        echo '['
-        echo "  \"$NODE_VERSION\","
-        echo "  \"$NODE_VERSION_MINUS_ONE\""
-        echo ']'
+        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_VERSION_MINUS_ONE" '[$v1, $v1]'
         echo EOF
         } >> "$GITHUB_OUTPUT"
+
+        # Sample output looks like this:
+        #
+        # nodeVersions<<EOF
+        # [
+        #   "18.15.0",
+        #   "17"
+        # ]
+        # EOF

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -1,6 +1,11 @@
 name: determine-node-versions
 description: Calculate Node and Node-1 versions for unit tests
 
+inputs:
+  nodeVersionOverride:
+    description: Semver version to set version and version-1
+    required: false
+
 outputs:
   nodeVersions:
     description: Node versions to be consumed by a workflow matrix
@@ -13,11 +18,11 @@ runs:
       shell: bash
       id: node-versions
       run: |
-        NODE_VERSION="${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}"
+        NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
         NODE_VERSION_MINUS_ONE="lts/-1"
 
-        if [ -n "${{ vars.NODE_VERSION_OVERRIDE }}" ]; then
-          NODE_VERSION_MAJOR=$(echo "${{ vars.NODE_VERSION_OVERRIDE }}" | cut -d '.' -f 1)
+        if [ -n "${{ inputs.nodeVersionOverride }}" ]; then
+          NODE_VERSION_MAJOR=$(echo "${{ inputs.nodeVersionOverride }}" | cut -d '.' -f 1)
           NODE_VERSION_MINUS_ONE="$((NODE_VERSION_MAJOR - 1))"
         fi
 

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -19,16 +19,22 @@ runs:
       id: node-versions
       run: |
         NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
-        NODE_VERSION_MINUS_ONE="lts/-1"
+        NODE_PREVIOUS_LTS="lts/-1"
 
         if [ -n "${{ inputs.nodeVersionOverride }}" ]; then
           NODE_VERSION_MAJOR=$(echo "${{ inputs.nodeVersionOverride }}" | cut -d '.' -f 1)
-          NODE_VERSION_MINUS_ONE="$((NODE_VERSION_MAJOR - 1))"
+
+          # LTS-1 will always be the previous LTS, which is always even. Here we calculate the nearest LTS
+          if [ $((NODE_VERSION_MAJOR % 2)) == 0 ]; then
+            NODE_PREVIOUS_LTS="$((NODE_VERSION_MAJOR - 2))"
+          else
+            NODE_PREVIOUS_LTS="$((NODE_VERSION_MAJOR - 1))"
+          fi
         fi
 
         {
         echo 'nodeVersions<<EOF'
-        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_VERSION_MINUS_ONE" '[$v1, $v2]'
+        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'
         echo EOF
         } >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -1,0 +1,31 @@
+name: determine-node-versions
+description: Calculate Node and Node-1 versions for unit tests
+
+outputs:
+  nodeVersions:
+    description: Node versions to be consumed by a workflow matrix
+    value: ${{ steps.node-versions.outputs.nodeVersions }}
+
+runs:
+  using: composite
+  steps:
+    - name: Determine node versions
+      shell: bash
+      id: node-versions
+      run: |
+        NODE_VERSION="${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}"
+        NODE_VERSION_MINUS_ONE="lts/-1"
+
+        if [ -n "${{ vars.NODE_VERSION_OVERRIDE }}" ]; then
+          NODE_VERSION_MAJOR=$(echo "${{ vars.NODE_VERSION_OVERRIDE }}" | cut -d '.' -f 1)
+          NODE_VERSION_MINUS_ONE="$((NODE_VERSION_MAJOR - 1))"
+        fi
+
+        {
+        echo 'nodeVersions<<EOF'
+        echo '['
+        echo "  \"$NODE_VERSION\","
+        echo "  \"$NODE_VERSION_MINUS_ONE\""
+        echo ']'
+        echo EOF
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -28,7 +28,7 @@ runs:
 
         {
         echo 'nodeVersions<<EOF'
-        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_VERSION_MINUS_ONE" '[$v1, $v1]'
+        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_VERSION_MINUS_ONE" '[$v1, $v2]'
         echo EOF
         } >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,30 @@
+name: retry
+description: a wrapper for nick-fields/retry with sensible defaults to make our workflow files cleaner
+
+inputs:
+  command:
+    required: true
+    description: The command to run
+  max_attempts:
+    description: Number of attempts to make before failing the step
+    default: "3"
+  retry_wait_seconds:
+    default: "60"
+    description: Number of seconds to wait before attempting the next retry
+  timeout_minutes:
+    default: "60"
+    description: Minutes to wait before attempt times out. Must only specify either minutes or seconds
+  retry_on:
+    default: "any"
+    description: Event to retry on. Currently supports [any (default), timeout, error]
+
+runs:
+  using: "composite"
+  steps:
+    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      with:
+        max_attempts: ${{ inputs.max_attempts }}
+        retry_wait_seconds: ${{ inputs.retry_wait_seconds }}
+        command: ${{ inputs.command }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        retry_on: ${{ inputs.retry_on }}

--- a/.github/actions/yarnInstallWithRetries/action.yml
+++ b/.github/actions/yarnInstallWithRetries/action.yml
@@ -9,6 +9,6 @@ runs:
   using: composite
   steps:
     - name: yarn install
-      uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+      uses: salesforcecli/github-workflows/.github/actions/retry@main
       with:
         command: yarn install --network-timeout 600000 ${{ inputs.ignore-scripts && '--ignore-scripts' || '' }}

--- a/.github/actions/yarnInstallWithRetries/action.yml
+++ b/.github/actions/yarnInstallWithRetries/action.yml
@@ -8,9 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-      name: yarn install
+    - name: yarn install
+      uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
       with:
-        max_attempts: 5
         command: yarn install --network-timeout 600000 ${{ inputs.ignore-scripts && '--ignore-scripts' || '' }}
-        timeout_minutes: 60

--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -22,11 +22,9 @@ jobs:
       - run: npm install -g @salesforce/change-case-management --omit=dev
       - name: Open CTC case
         id: ctc
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
           max_attempts: 5
-          retry_wait_seconds: 60
-          timeout_minutes: 60
           command: |
             CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json)
 

--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -22,7 +22,7 @@ jobs:
       - run: npm install -g @salesforce/change-case-management --omit=dev
       - name: Open CTC case
         id: ctc
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 5
           command: |

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -68,7 +68,7 @@ jobs:
           git commit -m 'chore: updates from devScripts' --no-verify
           git push origin --no-verify
       # sometimes pr can't create immediately
-      - uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+      - uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 5
           command: |

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -68,10 +68,8 @@ jobs:
           git commit -m 'chore: updates from devScripts' --no-verify
           git push origin --no-verify
       # sometimes pr can't create immediately
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      - uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
-          timeout_minutes: 60
-          retry_wait_seconds: 60
           max_attempts: 5
           command: |
             gh pr create --title 'refactor: devScripts update' --body 'created via github action [skip-validate-pr]' -l dependencies

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -88,19 +88,17 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.nodeVersion }}
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      - uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         name: cli install
         with:
           max_attempts: ${{ inputs.attempts }}
           command: npm install -g @salesforce/cli@nightly shx yarn-deduplicate --omit=dev
           timeout_minutes: 20
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+      - uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         name: git clone
         with:
           max_attempts: 20
           command: git clone -b ${{ inputs.branch}} --single-branch ${{ inputs.externalProjectGitUrl}} $(pwd)
-          # backoff 60 seconds because most failures are 429 (too many requests)
-          retry_wait_seconds: 60
           timeout_minutes: 20
       - name: Cache node modules
         if: inputs.useCache
@@ -139,13 +137,12 @@ jobs:
         run: yarn compile
       - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
         if: inputs.sfdxExecutablePath
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        name: NUTs with ${{ inputs.attempts }} attempts
+      - name: NUTs with ${{ inputs.attempts }} attempts
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
           max_attempts: ${{ inputs.attempts }}
           command: ${{ inputs.command }}
           retry_on: error
-          timeout_minutes: 60
         env:
           SF_DISABLE_TELEMETRY: true
           TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL }}

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -88,13 +88,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ inputs.nodeVersion }}
-      - uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+      - uses: salesforcecli/github-workflows/.github/actions/retry@main
         name: cli install
         with:
           max_attempts: ${{ inputs.attempts }}
           command: npm install -g @salesforce/cli@nightly shx yarn-deduplicate --omit=dev
           timeout_minutes: 20
-      - uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+      - uses: salesforcecli/github-workflows/.github/actions/retry@main
         name: git clone
         with:
           max_attempts: 20
@@ -138,7 +138,7 @@ jobs:
       - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
         if: inputs.sfdxExecutablePath
       - name: NUTs with ${{ inputs.attempts }} attempts
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: ${{ inputs.attempts }}
           command: ${{ inputs.command }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -73,24 +73,22 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        name: add CLI as global dependency
+      - name: add CLI as global dependency
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
           max_attempts: ${{ inputs.retries }}
           command: npm install @salesforce/cli@nightly -g
-          timeout_minutes: 60
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn compile
       - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
         if: inputs.sfdxExecutablePath
-      - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        name: NUTs with ${{ inputs.retries }} attempts
+      - name: NUTs with ${{ inputs.retries }} attempts
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
           max_attempts: ${{ inputs.retries }}
           command: ${{ inputs.command }}
           retry_on: error
-          timeout_minutes: 60
         env:
           TESTKIT_AUTH_URL: ${{ secrets.TESTKIT_AUTH_URL}}
           TESTKIT_HUB_USERNAME: ${{ secrets.TESTKIT_HUB_USERNAME }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -74,7 +74,7 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - name: add CLI as global dependency
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: ${{ inputs.retries }}
           command: npm install @salesforce/cli@nightly -g
@@ -84,7 +84,7 @@ jobs:
       - run: echo "TESTKIT_EXECUTABLE_PATH=${{inputs.sfdxExecutablePath}}" >> $GITHUB_ENV
         if: inputs.sfdxExecutablePath
       - name: NUTs with ${{ inputs.retries }} attempts
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: ${{ inputs.retries }}
           command: ${{ inputs.command }}

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -34,11 +34,9 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       # todo: download the macos tarball and pass that to the oclif pack:macos command
       - name: pack:macos
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
-          max_attempts: 3
           command: yarn pack:macos
-          timeout_minutes: 60
       - run: yarn upload:macos
       - run: yarn channel:promote --cli ${{ inputs.cli }} --version ${{ inputs.version }} --target ${{ inputs.channel }} --platform macos
         name: Promote macos to ${{ inputs.channel }} channel

--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       # todo: download the macos tarball and pass that to the oclif pack:macos command
       - name: pack:macos
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: yarn pack:macos
       - run: yarn upload:macos

--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -40,7 +40,7 @@ jobs:
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - name: pack tarballs
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: yarn pack:tarballs
           retry_on: error

--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -40,12 +40,10 @@ jobs:
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - name: pack tarballs
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
-          max_attempts: 3
           command: yarn pack:tarballs
           retry_on: error
-          timeout_minutes: 60
       - run: yarn pack:verify
       - run: yarn test:smoke-unix
       - if: inputs.upload

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -3,6 +3,6 @@ on:
 
 jobs:
   linux-unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@ew/retry-wrapper
   windows-unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@main
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@ew/retry-wrapper

--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -3,6 +3,6 @@ on:
 
 jobs:
   linux-unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@ew/retry-wrapper
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsLinux.yml@main
   windows-unit-tests:
-    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@ew/retry-wrapper
+    uses: salesforcecli/github-workflows/.github/workflows/unitTestsWindows.yml@main

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -19,12 +19,12 @@ jobs:
           fi
 
           {
-            echo 'nodeVersions<<EOF'
-            [
-              "$NODE_VERSION",
-              "$NODE_VERSION_MINUS_ONE"
-            ]
-            echo EOF
+          echo 'nodeVersions<<EOF'
+          echo '['
+          echo "  \"$NODE_VERSION\","
+          echo "  \"$NODE_VERSION_MINUS_ONE\""
+          echo ']'
+          echo EOF
           } >> "$GITHUB_OUTPUT"
 
   linux-unit-tests:

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -2,10 +2,36 @@ on:
   workflow_call:
 
 jobs:
+  determine-node-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      nodeVersions: ${{ steps.node-versions.outputs.nodeVersions }}
+    steps:
+      - name: Determine node versions
+        id: node-versions
+        run: |
+          NODE_VERSION="${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}"
+          NODE_VERSION_MINUS_ONE="lts/-1"
+
+          if [ -n "${{ vars.NODE_VERSION_OVERRIDE }}" ]; then
+            NODE_VERSION_MAJOR=$(echo "${{ vars.NODE_VERSION_OVERRIDE }}" | cut -d '.' -f 1)
+            NODE_VERSION_MINUS_ONE="$((NODE_VERSION_MAJOR - 1))"
+          fi
+
+          {
+            echo 'nodeVersions<<EOF'
+            [
+              "$NODE_VERSION",
+              "$NODE_VERSION_MINUS_ONE"
+            ]
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
   linux-unit-tests:
+    needs: determine-node-versions
     strategy:
       matrix:
-        node_version: [lts/-1, lts/*]
+        node_version: ${{ fromJSON(needs.determine-node-versions.outputs.nodeVersions) }}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -29,10 +55,8 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - name: yarn test
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
-          max_attempts: 2
           command: yarn test
-          timeout_minutes: 60
         env:
           SF_DISABLE_TELEMETRY: true

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
         id: determine-node-versions
         with:
-          nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }}
+          nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*' and 'lts/-1'
 
   linux-unit-tests:
     needs: determine-node-versions

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -3,29 +3,12 @@ on:
 
 jobs:
   determine-node-versions:
-    runs-on: ubuntu-latest
     outputs:
-      nodeVersions: ${{ steps.node-versions.outputs.nodeVersions }}
+      nodeVersions: ${{ steps.determine-node-versions.outputs.nodeVersions }}
+    runs-on: ubuntu-latest
     steps:
-      - name: Determine node versions
-        id: node-versions
-        run: |
-          NODE_VERSION="${{ vars.NODE_VERSION_OVERRIDE || 'lts/*' }}"
-          NODE_VERSION_MINUS_ONE="lts/-1"
-
-          if [ -n "${{ vars.NODE_VERSION_OVERRIDE }}" ]; then
-            NODE_VERSION_MAJOR=$(echo "${{ vars.NODE_VERSION_OVERRIDE }}" | cut -d '.' -f 1)
-            NODE_VERSION_MINUS_ONE="$((NODE_VERSION_MAJOR - 1))"
-          fi
-
-          {
-          echo 'nodeVersions<<EOF'
-          echo '['
-          echo "  \"$NODE_VERSION\","
-          echo "  \"$NODE_VERSION_MINUS_ONE\""
-          echo ']'
-          echo EOF
-          } >> "$GITHUB_OUTPUT"
+      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@main
+        id: determine-node-versions
 
   linux-unit-tests:
     needs: determine-node-versions

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -7,7 +7,7 @@ jobs:
       nodeVersions: ${{ steps.determine-node-versions.outputs.nodeVersions }}
     runs-on: ubuntu-latest
     steps:
-      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@main
+      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
         id: determine-node-versions
 
   linux-unit-tests:

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
         id: determine-node-versions
+        with:
+          nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }}
 
   linux-unit-tests:
     needs: determine-node-versions

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -7,7 +7,7 @@ jobs:
       nodeVersions: ${{ steps.determine-node-versions.outputs.nodeVersions }}
     runs-on: ubuntu-latest
     steps:
-      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
+      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@main
         id: determine-node-versions
         with:
           nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*' and 'lts/-1'
@@ -40,7 +40,7 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - name: yarn test
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: yarn test
         env:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -10,12 +10,13 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
         id: determine-node-versions
         with:
-          nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }}
+          nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*' and 'lts/-1'
 
   windows-unit-tests:
+    needs: determine-node-versions
     strategy:
       matrix:
-        node_version: [lts/-1, lts/*]
+        node_version: ${{ fromJSON(needs.determine-node-versions.outputs.nodeVersions) }}
       fail-fast: false
     runs-on: windows-latest
     steps:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -29,10 +29,8 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - name: yarn test
-        uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
         with:
-          max_attempts: 2
           command: yarn test
-          timeout_minutes: 60
         env:
           SF_DISABLE_TELEMETRY: true

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -2,6 +2,16 @@ on:
   workflow_call:
 
 jobs:
+  determine-node-versions:
+    outputs:
+      nodeVersions: ${{ steps.determine-node-versions.outputs.nodeVersions }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
+        id: determine-node-versions
+        with:
+          nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }}
+
   windows-unit-tests:
     strategy:
       matrix:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -7,7 +7,7 @@ jobs:
       nodeVersions: ${{ steps.determine-node-versions.outputs.nodeVersions }}
     runs-on: ubuntu-latest
     steps:
-      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@ew/retry-wrapper
+      - uses: salesforcecli/github-workflows/.github/actions/determineNodeVersions@main
         id: determine-node-versions
         with:
           nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*' and 'lts/-1'
@@ -40,7 +40,7 @@ jobs:
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
       - run: yarn build
       - name: yarn test
-        uses: salesforcecli/github-workflows/.github/actions/retry@ew/retry-wrapper
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           command: yarn test
         env:


### PR DESCRIPTION
> **IMPORTANT**
> Don't merge before we replace `@ew/retry-wrapper` with `@main`

- Adds a wrapper for `nick-fields/retry` with sensible defaults
- Adds an action for calculating Node Version and Node LTS -1 for unit tests
  - Works with `NODE_VERSION_OVERRIDE` [[example](https://github.com/salesforcecli/testPackageRelease/actions/runs/6734126949) with `18.15.0` and `16`]
  - Works without `NODE_VERSION_OVERRIDE` [[example](https://github.com/salesforcecli/testPackageRelease/actions/runs/6723446808/job/18273548456) with `lts/*` and `lts/-1`]
  - Finds the previous LTS by looking for the previous even number. [[example](https://github.com/salesforcecli/testPackageRelease/actions/runs/6734178025) with `17` and `16`]

[@W-14338799@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14338799)