### PR TITLE
Replace actions/create-release@v1

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           name: ${{ steps.changelog.outputs.tag }}
           tag: ${{ steps.changelog.outputs.tag }}
+          commit: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
           prerelease: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -80,11 +80,10 @@ jobs:
       - name: Create Github Release
         uses: ncipollo/release-action@v1.13.0
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
         with:
-          tag: ${{ steps.changelog.outputs.tag }}
           name: ${{ steps.changelog.outputs.tag }}
+          tag: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
           prerelease: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           skipIfReleaseExists: true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -78,12 +78,13 @@ jobs:
           output-file: ${{ steps.prereleaseTag.outputs.tag && 'false' || 'CHANGELOG.md' }} # If prerelease, do not write the changelog file
 
       - name: Create Github Release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1.13.0
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         env:
           GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.changelog.outputs.tag }}
-          release_name: ${{ steps.changelog.outputs.tag }}
+          tag: ${{ steps.changelog.outputs.tag }}
+          name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
           prerelease: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
+          skipIfReleaseExists: true

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -78,7 +78,7 @@ jobs:
           output-file: ${{ steps.prereleaseTag.outputs.tag && 'false' || 'CHANGELOG.md' }} # If prerelease, do not write the changelog file
 
       - name: Create Github Release
-        uses: ncipollo/release-action@v1.13.0
+        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         with:
           name: ${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -20,6 +20,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Deprecation warning
+        run: |
+          echo "::warning::WARNING: This workflow is deprecated in favor of create-github-release.yml\n
+                                    Update your worklows to use the new flow that supports prereleases\n
+                                    Docs: https://github.com/salesforcecli/github-workflows#prereleases\n
+                                    Example: https://github.com/salesforcecli/plugin-source/pull/927/files"
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
The GHA `actions/create-release@v1` has been deprecated for a while. The PR replaces that action with a similar action

[@W-14488760@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14488760)

### Example of this working
- PR: https://github.com/salesforcecli/testPackageRelease/pull/33
- Create prerelease action: https://github.com/salesforcecli/testPackageRelease/actions/runs/7022349666/job/19106430823#step:8:3
- Prerelease Release: https://github.com/salesforcecli/testPackageRelease/releases/tag/3.2.1-dev.0
- Prerelease Publish Action: https://github.com/salesforcecli/testPackageRelease/actions/runs/7022366002
- NPM version: https://www.npmjs.com/package/@salesforce/test-plugin117/v/3.2.1-dev.0
> PR was merged...
- Create release action: https://github.com/salesforcecli/testPackageRelease/actions/runs/7022411042/job/19106613925#step:8:3
- Release: https://github.com/salesforcecli/testPackageRelease/releases/tag/3.2.1
  - Note: changelog created and is marked as `latest`
- Publish action: https://github.com/salesforcecli/testPackageRelease/actions/runs/7022425248
- NPM version: https://www.npmjs.com/package/@salesforce/test-plugin117/v/3.2.1
  - Note: marked as `latest`

NOTE: I am going to leave the `actions/create-release@v1` in [githubRelease.yml](https://github.com/salesforcecli/github-workflows/blob/main/.github/workflows/githubRelease.yml#L53) since it is deprecated. 