### PR TITLE
External developer friendly changes

### DIFF
--- a/.github/actions/getGithubUserInfo/action.yml
+++ b/.github/actions/getGithubUserInfo/action.yml
@@ -21,7 +21,7 @@ runs:
       if: inputs.SVC_CLI_BOT_GITHUB_TOKEN == ''
       uses: actions/github-script@v3
       with:
-        script: core.setFailed("You must pass a Github Token with Repo Access as SVC_CLI_BOT_GITHUB_TOKEN")
+        script: core.setFailed("You must pass a Github Token with repo write access as SVC_CLI_BOT_GITHUB_TOKEN")
     - name: Get Github user info
       id: user-info
       shell: bash

--- a/.github/actions/getGithubUserInfo/action.yml
+++ b/.github/actions/getGithubUserInfo/action.yml
@@ -38,4 +38,4 @@ runs:
 
         echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/actions/getGithubUserInfo/action.yml
+++ b/.github/actions/getGithubUserInfo/action.yml
@@ -1,0 +1,41 @@
+name: getGithubUserInfo
+description: Looks up Github user info for a Token
+
+inputs:
+  GITHUB_TOKEN:
+    description: Github token
+    required: true
+
+outputs:
+  username:
+    description: Github username associated with the provided token
+    value: ${{ steps.user-info.outputs.username }}
+  email:
+    description: Github email associated with the provided token
+    value: ${{ steps.user-info.outputs.email }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get Github user info
+      id: user-info
+      shell: bash
+      run: |
+        USER_INFO=$(gh api user)
+
+        GH_USERNAME=$(echo $USER_INFO | jq -r '.login')
+        EMAIL=$(echo $USER_INFO | jq -r '.email')
+
+        echo "username=$(echo $USER_INFO | jq -r '.login')" >> "$GITHUB_OUTPUT"
+
+        if [[ -z "$EMAIL" || $EMAIL == 'null' ]]; then
+          # Email is empty (likely set to private)
+          ID=$(echo $USER_INFO | jq -r '.id')
+
+          # https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address
+          EMAIL="$ID+$GH_USERNAME@users.noreply.github.com"
+        fi
+
+        echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/getGithubUserInfo/action.yml
+++ b/.github/actions/getGithubUserInfo/action.yml
@@ -2,7 +2,7 @@ name: getGithubUserInfo
 description: Looks up Github user info for a Token
 
 inputs:
-  GITHUB_TOKEN:
+  SVC_CLI_BOT_GITHUB_TOKEN:
     description: Github token
     required: true
 
@@ -17,9 +17,16 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate token is passed
+      if: inputs.SVC_CLI_BOT_GITHUB_TOKEN == ''
+      uses: actions/github-script@v3
+      with:
+        script: core.setFailed("You must pass a Github Token with Repo Access as SVC_CLI_BOT_GITHUB_TOKEN")
     - name: Get Github user info
       id: user-info
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.SVC_CLI_BOT_GITHUB_TOKEN }}
       run: |
         USER_INFO=$(gh api user)
 
@@ -37,5 +44,3 @@ runs:
         fi
 
         echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/actions/gitConfig/action.yml
+++ b/.github/actions/gitConfig/action.yml
@@ -1,11 +1,20 @@
 name: gitConfig
 description: "Sets git username/email and push behavior"
+
+inputs:
+  username:
+    description: "Github username to set as `user.name`. TIP: Use getGithubUserInfo to look up username from a Github token."
+    required: true
+  email:
+    description: "Github email to set as `user.email`. TIP: Use getGithubUserInfo to look up email from a Github token."
+    required: true
+
 runs:
   using: composite
   steps:
     - run: git config --global push.default current
       shell: bash
-    - run: git config --global user.email svc_cli_bot@salesforce.com
+    - run: git config --global user.name ${{ inputs.username }}
       shell: bash
-    - run: git config --global user.name svc-cli-bot
+    - run: git config --global user.email ${{ inputs.email }}
       shell: bash

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -4,6 +4,7 @@ on:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
         description: A Github PAT with repo access.
+        required: true
 
     inputs:
       prerelease:
@@ -26,7 +27,7 @@ jobs:
         id: github-user-info
         uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
         with:
-          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+          SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
-        description: a github PAT with repo access
+        description: A Github PAT with repo access.
 
     inputs:
       prerelease:
@@ -22,6 +22,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Get Github user info
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
@@ -65,8 +71,8 @@ jobs:
         id: changelog
         uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
-          git-user-name: svc-cli-bot
-          git-user-email: svc_cli_bot@salesforce.com
+          git-user-name: ${{ steps.github-user-info.outputs.username }}
+          git-user-email: ${{ steps.github-user-info.outputs.email }}
           github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           tag-prefix: ""
           # Setting 'release-count' to 0 will keep ALL releases in the change log file (no pruning)

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
         with:
           SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
-        description: A Github PAT with repo access.
+        description: A Github PAT with repo write access.
         required: true
 
     inputs:

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
-        description: A Github PAT with repo access.
+        description: A Github PAT with repo write access.
         required: true
 
 jobs:

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -3,6 +3,7 @@ on:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
         description: A Github PAT with repo access.
+        required: true
 
 jobs:
   # what is the RC version, numerically?

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -1,5 +1,8 @@
 on:
   workflow_call:
+    secrets:
+      SVC_CLI_BOT_GITHUB_TOKEN:
+        description: A Github PAT with repo access.
 
 jobs:
   # what is the RC version, numerically?
@@ -35,7 +38,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+
+      - name: Get Github user info
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+
       - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+        with:
+          username: ${{ steps.github-user-info.outputs.username }}
+          email: ${{ steps.github-user-info.outputs.email }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -41,11 +41,11 @@ jobs:
 
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 
-      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@ew/external-friendly
         with:
           username: ${{ steps.github-user-info.outputs.username }}
           email: ${{ steps.github-user-info.outputs.email }}

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 
-      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@ew/external-friendly
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
         with:
           username: ${{ steps.github-user-info.outputs.username }}
           email: ${{ steps.github-user-info.outputs.email }}

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -48,18 +48,12 @@ jobs:
           script: |
             core.setFailed('Prerelease requires a dist tag name in your package.json like beta in 1.1.1-beta.0')
 
-      - name: Get Github user info
-        id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
-        with:
-          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
-          git-user-name: ${{ steps.github-user-info.outputs.username }}
-          git-user-email: ${{ steps.github-user-info.outputs.email }}
+          git-user-name: svc-cli-bot
+          git-user-email: svc_cli_bot@salesforce.com
           github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           tag-prefix: ""
           # Setting 'release-count' to 0 will keep ALL releases in the change log (no pruning)

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -41,12 +41,18 @@ jobs:
           script: |
             core.setFailed('Prerelease requires a dist tag name in your package.json like beta in 1.1.1-beta.0')
 
+      - name: Get Github user info
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+
       - name: Conventional Changelog Action
         id: changelog
         uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
         with:
-          git-user-name: svc-cli-bot
-          git-user-email: svc_cli_bot@salesforce.com
+          git-user-name: ${{ steps.github-user-info.outputs.username }}
+          git-user-email: ${{ steps.github-user-info.outputs.email }}
           github-token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
           tag-prefix: ""
           # Setting 'release-count' to 0 will keep ALL releases in the change log (no pruning)

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -1,4 +1,15 @@
 name: tag and github release
+#
+#
+#
+#
+# -----------------------------------------------------------------------
+# NOTE: This workflow is deprecated in favor of create-github-release.yml
+# -----------------------------------------------------------------------
+#
+#
+#
+#
 on:
   workflow_call:
     secrets:
@@ -11,10 +22,6 @@ on:
         required: false
         default: false
         description: use a prerelease instead of a regular release
-
-# -----------------------------------------------------------------------
-# NOTE: This workflow is deprecated in favor of create-github-release.yml
-# -----------------------------------------------------------------------
 
 jobs:
   release:

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -21,10 +21,10 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@ew/external-friendly
         with:
           username: ${{ steps.github-user-info.outputs.username }}
           email: ${{ steps.github-user-info.outputs.email }}

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -1,5 +1,8 @@
 on:
   workflow_call:
+    secrets:
+      SVC_CLI_BOT_GITHUB_TOKEN:
+        description: A Github PAT with repo access.
 
 jobs:
   publish:
@@ -16,7 +19,15 @@ jobs:
           node-version: lts/*
           cache: yarn
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+      - name: Get Github user info
+        id: github-user-info
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
+        with:
+          token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
       - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
+        with:
+          username: ${{ steps.github-user-info.outputs.username }}
+          email: ${{ steps.github-user-info.outputs.email }}
       - name: build docs
         run: |
           rm -rf docs

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
-        description: A Github PAT with repo access.
+        description: A Github PAT with repo write access.
         required: true
 
 jobs:

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -3,6 +3,7 @@ on:
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN:
         description: A Github PAT with repo access.
+        required: true
 
 jobs:
   publish:

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - name: Get Github user info
         id: github-user-info
-        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@ew/external-friendly
+        uses: salesforcecli/github-workflows/.github/actions/getGithubUserInfo@main
         with:
           token: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@ew/external-friendly
+      - uses: salesforcecli/github-workflows/.github/actions/gitConfig@main
         with:
           username: ${{ steps.github-user-info.outputs.username }}
           email: ${{ steps.github-user-info.outputs.email }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Reusable workflows and actions
 >
 > - Create a new PAT with Repo access
 >   - It is recommended that this is a service account user
+>   - Note: This user/bot will need to have access to push to your repo's default branch. This can be configured in the branch protection rules.
 > - Add the PAT as an Actions [Organization secret](https://github.com/organizations/salesforcecli/settings/secrets/actions)
 >   - Set the `Name` to `SVC_CLI_BOT_GITHUB_TOKEN`
 >   - Paste in your new PAT as the `Value`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Reusable workflows and actions
 
+> [!IMPORTANT]
+> Many of these workflows require a Personal Access Token to function.
+>
+> - Create a new PAT with Repo access
+>   - It is recommended that this is a service account user
+> - Add the PAT as an Actions [Organization secret](https://github.com/organizations/salesforcecli/settings/secrets/actions)
+>   - Set the `Name` to `SVC_CLI_BOT_GITHUB_TOKEN`
+>   - Paste in your new PAT as the `Value`
+>   - Set `Repository Access` to 'Selected Repositories'
+>   - Click the gear icon to select repos that need access to the PAT
+>     - This can be edited later
+>   - Click `Add Secret`
+
 ## Opinionated publish process for npm
 
 > github is the source of truth for code AND releases. Get the version/tag/release right on github, then publish to npm based on that.
@@ -94,18 +107,20 @@ jobs:
 `main` will release to `latest`. Other branches can create github prereleases and publish to other npm dist tags.
 
 You can create a prerelease one of two ways:
+
 1. Create a branch with the `prerelease/**` prefix. Example `prerelease/my-fix`
-    1. Once a PR is opened, every commit pushed to this branch will create a prerelease
-    2. The default prerelease tag will be `dev`. If another tag is desired, manually set it in your `package.json`. Example: `1.2.3-beta.0`
+   1. Once a PR is opened, every commit pushed to this branch will create a prerelease
+   2. The default prerelease tag will be `dev`. If another tag is desired, manually set it in your `package.json`. Example: `1.2.3-beta.0`
 1. Manually run the `create-github-release` workflow in the Actions tab
-    1. Click `Run workflow`   
-        1. Select the branch you want to create a prerelease from
-        1. Enter the desired prerelease tag: `dev`, `beta`, etc
+   1. Click `Run workflow`
+      1. Select the branch you want to create a prerelease from
+      1. Enter the desired prerelease tag: `dev`, `beta`, etc
 
 > [!NOTE]  
 > Since conventional commits are used, there is no need to manually remove the prerelease tag from your `package.json`. Once the PR is merged into `main`, conventional commits will bump the version as expected (patch for `fix:`, minor for `feat:`, etc)
 
 Setup:
+
 1. Configure the branch rules for wherever you want to release from
 1. Modify your release and publish workflows like the following
 


### PR DESCRIPTION
> [!WARNING]
> Do not merge yet, additional PRs incoming
> TODO: Revert `ew/external-friendly` branch refs

We hard coded our svc-cli-bot username/email in a few spots. Making these workflows not useable to external developers. 
This PR looks up the username/password based on the Github Token being used. Additional changes are made to take advantage of this lookup.

Example of a Release working on an external plugin: https://github.com/iowillhoit/plugin-workflow-test/actions/runs/7748104245
Example of this working on an internal plugin (using secrets inherit) https://github.com/salesforcecli/testPackageRelease/actions/runs/7759564485/job/21163873201#step:8:27

[@W-14809762@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14809762)


Other PRs:
https://github.com/oclif/plugin-plugins/pull/784
https://github.com/salesforcecli/plugin-trust/pull/720
https://github.com/salesforcecli/plugin-template-sf-external/pull/110/
https://github.com/forcedotcom/source-deploy-retrieve/pull/1226
https://github.com/salesforcecli/cli/pull/1456
