### PR TITLE
fix: windows longpath

### DIFF
--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -86,6 +86,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - run: git config --system core.longpaths true
+        if: ${{ runner.os == 'Windows' }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.nodeVersion }}

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -85,6 +85,7 @@ jobs:
     name: ${{ inputs.command }}
     runs-on: ${{ inputs.os }}
     steps:
+      - run: git config --system core.longpaths true
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.nodeVersion }}

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -59,6 +59,7 @@ jobs:
     name: ${{ inputs.command }}
     runs-on: ${{ inputs.os }}
     steps:
+      - run: git config --system core.longpaths true
       - uses: actions/checkout@v4
       - uses: google/wireit@setup-github-actions-caching/v1
       - uses: actions/setup-node@v4

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - run: git config --system core.longpaths true
+        if: ${{ runner.os == 'Windows' }}
+
       - uses: actions/checkout@v4
       - uses: google/wireit@setup-github-actions-caching/v1
       - uses: actions/setup-node@v4

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
     runs-on: windows-latest
     steps:
+      - run: git config --system core.longpaths true
       - uses: actions/checkout@v4
       - uses: google/wireit@setup-github-actions-caching/v1
         continue-on-error: true


### PR DESCRIPTION
fix errors like https://github.com/forcedotcom/source-deploy-retrieve/actions/runs/7587086107/job/20666713904#step:2:50

https://github.com/forcedotcom/source-deploy-retrieve/pull/1218 shows this in action.  Had to keep it from running on linux using `if` to prevent `error: could not lock config file /etc/gitconfig: Permission denied`