### PR TITLE
feat: add readme-command input

### DIFF
--- a/.github/actions/generateOclifReadme/action.yml
+++ b/.github/actions/generateOclifReadme/action.yml
@@ -10,8 +10,8 @@ inputs:
     required: true
   pre-release-identifier:
     description: The name of the prerelease channel (e.g. dev, beta)
-  command:
-    description: The command to run to generate the readme.
+  multi:
+    description: Create a different markdown page for each topic.
 
 runs:
   using: composite
@@ -44,13 +44,9 @@ runs:
       run: |
         yarn install
         yarn tsc
-        if [[ -n "${{ inputs.command }}" ]]; then
-          command="${{ inputs.command }}"
-        else
-          command="yarn oclif readme"
-        fi
-        ${command} \
+        yarn oclif readme \
           --no-aliases \
           --version ${{ steps.next-version.outputs.tag }} \
+          ${{ inputs.multi && '--multi' || '' }} \
           --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>" \
-          || echo "::warning::'${command}' failed. Check the logs."
+          || echo "::warning::'oclif readme' failed. Check the logs."

--- a/.github/actions/generateOclifReadme/action.yml
+++ b/.github/actions/generateOclifReadme/action.yml
@@ -10,6 +10,8 @@ inputs:
     required: true
   pre-release-identifier:
     description: The name of the prerelease channel (e.g. dev, beta)
+  command:
+    description: The command to run to generate the readme.
 
 runs:
   using: composite
@@ -42,8 +44,13 @@ runs:
       run: |
         yarn install
         yarn tsc
-        yarn oclif readme \
+        if [[ -n "${{ inputs.command }}" ]]; then
+          command="${{ inputs.command }}"
+        else
+          command="yarn oclif readme"
+        fi
+        ${command} \
           --no-aliases \
           --version ${{ steps.next-version.outputs.tag }} \
           --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>" \
-          || echo "::warning::'oclif readme' failed. Check the logs."
+          || echo "::warning::'${command}' failed. Check the logs."

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme }}
-        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@mdonnalley/support-mutli-readme
+        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@main
         with:
           skip-on-empty: ${{ inputs.skip-on-empty }}
           pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: true
         description: "Generate oclif readme"
+      readme-command:
+        type: string
+        description: "Command to use for generating the readme"
 
 jobs:
   release:
@@ -62,11 +65,12 @@ jobs:
 
       - name: Generate oclif readme
         if: ${{ inputs.generate-readme }}
-        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@main
+        uses: salesforcecli/github-workflows/.github/actions/generateOclifReadme@mdonnalley/support-mutli-readme
         with:
           skip-on-empty: ${{ inputs.skip-on-empty }}
           pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
           pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
+          command: ${{ inputs.readme-command }}
 
       - name: Conventional Changelog Action
         id: changelog

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -18,9 +18,10 @@ on:
         type: boolean
         default: true
         description: "Generate oclif readme"
-      readme-command:
-        type: string
-        description: "Command to use for generating the readme"
+      readme-multi:
+        type: boolean
+        description: "Create a different markdown page for each topic."
+        default: false
 
 jobs:
   release:
@@ -70,7 +71,7 @@ jobs:
           skip-on-empty: ${{ inputs.skip-on-empty }}
           pre-release: ${{ steps.prereleaseTag.outputs.tag && 'true' || 'false' }}
           pre-release-identifier: ${{ steps.prereleaseTag.outputs.tag }}
-          command: ${{ inputs.readme-command }}
+          multi: ${{ inputs.readme-multi }}
 
       - name: Conventional Changelog Action
         id: changelog


### PR DESCRIPTION
Add ability to pass in custom command for readme generation


🟢 Passing build: https://github.com/oclif/oclif/actions/runs/8362307426/job/22892575033
🟢 Generated readme with custom command: https://github.com/oclif/oclif/tree/4.6.1-dev.0/docs