### PR TITLE
Input is a string in Actions

### DIFF
--- a/.github/actions/generateOclifReadme/action.yml
+++ b/.github/actions/generateOclifReadme/action.yml
@@ -47,6 +47,6 @@ runs:
         yarn oclif readme \
           --no-aliases \
           --version ${{ steps.next-version.outputs.tag }} \
-          ${{ inputs.multi && '--multi' || '' }} \
+          ${{ inputs.multi === 'true' && '--multi' || '' }} \
           --repository-prefix "<%- repo %>/blob/<%- version %>/<%- commandPath %>" \
           || echo "::warning::'oclif readme' failed. Check the logs."


### PR DESCRIPTION
Github Actions handle inputs differently than Workflows. Everything is a string. So `'false'` was truthy and causing the `--mutli` flag to be added. 

Related to [@W-15295078@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15295078)