### PR TITLE
Use node 'current' in UT, allow disable

### DIFF
--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -18,8 +18,8 @@ runs:
       shell: bash
       id: node-versions
       run: |
-        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT"
-        # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will be disabled
+        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT" to "true"
+        # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will also be disabled
         NODE_VERSION_CURRENT="current"
         NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
         NODE_PREVIOUS_LTS="lts/-1"
@@ -37,7 +37,7 @@ runs:
 
         {
         echo "nodeVersions<<EOF"
-        if [ "$NODE_VERSION" = "lts/*" ] && [ -z "$UT_DISABLE_NODE_CURRENT" ]; then
+        if [ "$NODE_VERSION" = "lts/*" ] && [ "${{ vars.UT_DISABLE_NODE_CURRENT }}" != "true" ]; then
             jq -n --arg v1 "$NODE_VERSION_CURRENT" --arg v2 "$NODE_VERSION" --arg v3 "$NODE_PREVIOUS_LTS"  '[$v1, $v2, $v3]'
         else
             jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -18,6 +18,9 @@ runs:
       shell: bash
       id: node-versions
       run: |
+        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT"
+        # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will be disabled
+        NODE_VERSION_CURRENT="current"
         NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
         NODE_PREVIOUS_LTS="lts/-1"
 
@@ -33,16 +36,30 @@ runs:
         fi
 
         {
-        echo 'nodeVersions<<EOF'
-        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'
-        echo EOF
+        echo "nodeVersions<<EOF"
+        if [ "$NODE_VERSION" = "lts/*" ] && [ -z "$UT_DISABLE_NODE_CURRENT" ]; then
+            jq -n --arg v1 "$NODE_VERSION_CURRENT" --arg v2 "$NODE_VERSION" --arg v3 "$NODE_PREVIOUS_LTS"  '[$v1, $v2, $v3]'
+        else
+            jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'
+        fi
+        echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
         # Sample output looks like this:
         #
         # nodeVersions<<EOF
         # [
+        #   "current",
+        #   "lts/*",
+        #   "lts/-1",
+        # ]
+        # EOF
+        #
+        # OR...
+        #
+        # nodeVersions<<EOF
+        # [
         #   "18.15.0",
-        #   "17"
+        #   "16"
         # ]
         # EOF


### PR DESCRIPTION
We had disabled Node `current` in unit tests when we were having issues with Node 21. This brings it back along with the ability to disable it with an env var in Github Actions (either at the org or repo level). 

[@W-15716084@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15716084)