### PR TITLE
Used node "current" in unit tests. Also allow disabling via env var

### DIFF
--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -5,6 +5,9 @@ inputs:
   nodeVersionOverride:
     description: Semver version to set version and version-1
     required: false
+  nodeDisableCurrent:
+    description: Disable testing on Node "current"
+    required: false
 
 outputs:
   nodeVersions:
@@ -18,7 +21,7 @@ runs:
       shell: bash
       id: node-versions
       run: |
-        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT" to "true"
+        # Current can be disabled by setting the "nodeDisableCurrent" input to "true"
         # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will also be disabled
         NODE_VERSION_CURRENT="current"
         NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
@@ -37,7 +40,7 @@ runs:
 
         {
         echo "nodeVersions<<EOF"
-        if [ "$NODE_VERSION" = "lts/*" ] && [ "${{ vars.UT_DISABLE_NODE_CURRENT }}" != "true" ]; then
+        if [ "$NODE_VERSION" = "lts/*" ] && [ "${{ inputs.nodeDisableCurrent }}" != "true" ]; then
             jq -n --arg v1 "$NODE_VERSION_CURRENT" --arg v2 "$NODE_VERSION" --arg v3 "$NODE_PREVIOUS_LTS"  '[$v1, $v2, $v3]'
         else
             jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -18,8 +18,8 @@ runs:
       shell: bash
       id: node-versions
       run: |
-        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT"
-        # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will be disabled
+        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT" to "true"
+        # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will also be disabled
         NODE_VERSION_CURRENT="current"
         NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
         NODE_PREVIOUS_LTS="lts/-1"
@@ -37,7 +37,7 @@ runs:
 
         {
         echo "nodeVersions<<EOF"
-        if [ "$NODE_VERSION" = "lts/*" ] && [ -z "$UT_DISABLE_NODE_CURRENT" ]; then
+        if [ "$NODE_VERSION" = "lts/*" ] && [ "${{ vars.UT_DISABLE_NODE_CURRENT }}" != "true" ]; then
             jq -n --arg v1 "$NODE_VERSION_CURRENT" --arg v2 "$NODE_VERSION" --arg v3 "$NODE_PREVIOUS_LTS"  '[$v1, $v2, $v3]'
         else
             jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'

--- a/.github/actions/determineNodeVersions/action.yml
+++ b/.github/actions/determineNodeVersions/action.yml
@@ -18,6 +18,9 @@ runs:
       shell: bash
       id: node-versions
       run: |
+        # Current can be disabled by setting the GHA var "UT_DISABLE_NODE_CURRENT"
+        # IF "NODE_VERSION" is overridden, "NODE_VERSION_CURRENT" will be disabled
+        NODE_VERSION_CURRENT="current"
         NODE_VERSION="${{ inputs.nodeVersionOverride || 'lts/*' }}"
         NODE_PREVIOUS_LTS="lts/-1"
 
@@ -33,16 +36,30 @@ runs:
         fi
 
         {
-        echo 'nodeVersions<<EOF'
-        jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'
-        echo EOF
+        echo "nodeVersions<<EOF"
+        if [ "$NODE_VERSION" = "lts/*" ] && [ -z "$UT_DISABLE_NODE_CURRENT" ]; then
+            jq -n --arg v1 "$NODE_VERSION_CURRENT" --arg v2 "$NODE_VERSION" --arg v3 "$NODE_PREVIOUS_LTS"  '[$v1, $v2, $v3]'
+        else
+            jq -n --arg v1 "$NODE_VERSION" --arg v2 "$NODE_PREVIOUS_LTS" '[$v1, $v2]'
+        fi
+        echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
         # Sample output looks like this:
         #
         # nodeVersions<<EOF
         # [
+        #   "current",
+        #   "lts/*",
+        #   "lts/-1",
+        # ]
+        # EOF
+        #
+        # OR...
+        #
+        # nodeVersions<<EOF
+        # [
         #   "18.15.0",
-        #   "17"
+        #   "16"
         # ]
         # EOF

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -11,6 +11,7 @@ jobs:
         id: determine-node-versions
         with:
           nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*' and 'lts/-1'
+          nodeDisableCurrent: ${{ vars.UT_DISABLE_NODE_CURRENT }} # default is falsy
 
   linux-unit-tests:
     needs: determine-node-versions

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -11,6 +11,7 @@ jobs:
         id: determine-node-versions
         with:
           nodeVersionOverride: ${{ vars.NODE_VERSION_OVERRIDE }} # default is 'lts/*' and 'lts/-1'
+          nodeDisableCurrent: ${{ vars.UT_DISABLE_NODE_CURRENT }} # default is falsy
 
   windows-unit-tests:
     needs: determine-node-versions


### PR DESCRIPTION
We had disabled Node current in unit tests when we were having issues with Node 21. This brings it back along with the ability to disable it with an env var in Github Actions (either at the org or repo level).

[@W-15716084@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15716084)