### PR TITLE
ci: upload mac/win installers to release

### DIFF
--- a/.github/workflows/packUploadMac.yml
+++ b/.github/workflows/packUploadMac.yml
@@ -40,3 +40,8 @@ jobs:
       - run: yarn upload:macos
       - run: yarn channel:promote --cli ${{ inputs.cli }} --version ${{ inputs.version }} --target ${{ inputs.channel }} --platform macos
         name: Promote macos to ${{ inputs.channel }} channel
+      - name: upload artifacts to github release
+        run: |
+          gh release upload ${{ inputs.version }} ./dist/sf-*.pkg --clobber --repo ${{ github.repository}}
+        env:
+          GH_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/packUploadWindows.yml
+++ b/.github/workflows/packUploadWindows.yml
@@ -44,3 +44,8 @@ jobs:
       - run: yarn upload:win
       - run: yarn channel:promote --cli ${{ inputs.cli }} --version ${{ inputs.version }} --target ${{ inputs.channel }} --platform win
         name: Promote win to ${{ inputs.channel }} channel
+      - name: upload artifacts to github release
+        run: |
+          gh release upload ${{ inputs.version }} ./dist/sf-*.exe --clobber --repo ${{ github.repository}}
+        env:
+          GH_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -55,10 +55,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - if: inputs.upload
-        run: gh release upload ${{ inputs.version }} ./dist/*.gz --clobber --repo ${{ github.repository}}
-        env:
-          GH_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
-      - if: inputs.upload
-        run: gh release upload ${{ inputs.version }} ./dist/*.xz --clobber --repo ${{ github.repository}}
+        run: |
+          gh release upload ${{ inputs.version }} ./dist/*.gz --clobber --repo ${{ github.repository}}
+          gh release upload ${{ inputs.version }} ./dist/*.xz --clobber --repo ${{ github.repository}}
         env:
           GH_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
WI: it doesn't save time to download the tarballs to reuse vs. packing them from source in parallel.  Saving 20s would take extra work to oclif pack cmd, not positive ROI.

@W-12592230@