### PR TITLE
Update external actions

### DIFF
--- a/.github/actions/generateOclifReadme/action.yml
+++ b/.github/actions/generateOclifReadme/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Get the next version for oclif readme
       id: next-version
       if: ${{ steps.is-oclif-plugin.outputs.bool == 'true' }}
-      uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+      uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
       with:
         tag-prefix: ""
         skip-version-file: true # Do not update the version in the package.json

--- a/.github/actions/get-json-property/action.yml
+++ b/.github/actions/get-json-property/action.yml
@@ -1,0 +1,35 @@
+name: get-json-property
+description: Get a property from a json file using jq
+
+# Examples:
+# prop_path: version
+# prop_path: devDependencies["@salesforce/dev-scripts"]
+
+
+inputs:
+  path:
+    required: true
+    description: Json file to look up prop (package.json)
+  prop_path:
+    required: true
+    description: jq query to search (version)
+
+outputs:
+  prop:
+    description: The value of the prop_path
+    value: ${{ steps.jq.outputs.prop }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get property from json file
+      id: jq
+      shell: bash
+      run: |
+        PROP=$(jq -r '.${{ inputs.prop_path }}' ${{ inputs.path }})
+        echo "prop=$PROP" >> "$GITHUB_OUTPUT"
+    - name: Exit if prop was not found
+      if: ${{ steps.jq.outputs.prop == 'null' }}
+      uses: actions/github-script@v7
+      with:
+        script: core.setFailed("Property '${{ inputs.prop_path }}' not found in ${{ inputs.path }}")

--- a/.github/actions/getGithubUserInfo/action.yml
+++ b/.github/actions/getGithubUserInfo/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - name: Validate token is passed
       if: inputs.SVC_CLI_BOT_GITHUB_TOKEN == ''
-      uses: actions/github-script@v3
+      uses: actions/github-script@v7
       with:
         script: core.setFailed("You must pass a Github Token with repo write access as SVC_CLI_BOT_GITHUB_TOKEN")
     - name: Get Github user info

--- a/.github/actions/getPreReleaseTag/action.yml
+++ b/.github/actions/getPreReleaseTag/action.yml
@@ -3,7 +3,7 @@ description: read package.json and return the version suffix (ex 'beta' if x.y.z
 
 outputs:
   tag:
-    value: ${{ steps.tag.outputs.match }}
+    value: ${{ steps.parsed.outputs.prerelease }}
     description: version suffix (ex 'beta' if x.y.z-beta.0 ), if exists in package.json
   version:
     value: ${{ steps.packageVersion.outputs.prop }}
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: notiz-dev/github-action-json-property@7a701887f4b568b23eb7b78bb0fc49aaeb1b68d3
+    - uses: salesforcecli/github-workflows/.github/actions/get-json-property@main
       id: packageVersion
       with:
         path: "package.json"
@@ -21,20 +21,10 @@ runs:
     - run: echo "found version ${{ steps.packageVersion.outputs.prop  }}"
       shell: bash
 
-    - uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3
-      id: versionSuffix
+    - uses: salesforcecli/github-workflows/.github/actions/parse-semver@main
+      id: parsed
       with:
         input_string: ${{ steps.packageVersion.outputs.prop }}
 
-    - run: echo "found prerelease ${{ steps.versionSuffix.outputs.prerelease }}"
-      shell: bash
-
-    - uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
-      id: tag
-      with:
-        text: ${{ steps.versionSuffix.outputs.prerelease }}
-        # at this point, we have just the prerelease section, but it includes the final .0 or whatever
-        regex: '.*(?=\.\d+)'
-
-    - run: echo "found tag ${{ steps.tag.outputs.match }}"
+    - run: echo "found prerelease tag ${{ steps.parsed.outputs.prerelease }}"
       shell: bash

--- a/.github/actions/parse-semver/action.yml
+++ b/.github/actions/parse-semver/action.yml
@@ -1,0 +1,56 @@
+name: Parse Semver
+
+description: Extracts major, minor, patch, prerelease, and full version from a given semver.
+
+inputs:
+  input_string:
+    description: 'The semver version to parse'
+    required: true
+
+outputs:
+  major:
+    description: 'MAJOR part of the semver'
+    value: ${{ steps.parse.outputs.major }}
+  minor:
+    description: 'MINOR part of the semver'
+    value: ${{ steps.parse.outputs.minor }}
+  patch:
+    description: 'PATCH part of the semver'
+    value: ${{ steps.parse.outputs.patch }}
+  prerelease:
+    description: 'Prerelease part of the semver'
+    value: ${{ steps.parse.outputs.prerelease }}
+  fullversion:
+    description: 'Full representation of the semver'
+    value: ${{ steps.parse.outputs.fullversion }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse Semver
+      id: parse
+      shell: bash
+      run: |
+        FULL_VERSION="${{ inputs.version }}"
+        VERSION="${FULL_VERSION#v}"
+
+        # Split version into parts
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+        # Check if PATCH contains prerelease info and extract it
+        if [[ "$PATCH" == *-* ]]; then
+            PRERELEASE=$(echo "$PATCH" | cut -d- -f2 | cut -d. -f1)
+            PATCH=$(echo "$PATCH" | cut -d- -f1)
+        fi
+
+        # Set outputs
+        echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+        echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+        echo "patch=$PATCH" >> "$GITHUB_OUTPUT"
+        echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+        echo "fullversion=$FULL_VERSION" >> "$GITHUB_OUTPUT"
+    - name: Exit if major, minor, or patch not found
+      if: ${{ !steps.parse.outputs.major || !steps.parse.outputs.minor || !steps.parse.outputs.patch }}
+      uses: actions/github-script@v7
+      with:
+        script: core.setFailed("Error parsing semver ${{ inputs.version }}\nMajor:${{ steps.parse.outputs.major }}\nMinor:${{ steps.parse.outputs.minor }}\nPatch:${{ steps.parse.outputs.patch }}")

--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: nick-fields/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+    - uses: nick-fields/retry@3f757583fb1b1f940bc8ef4bf4734c8dc02a5847
       with:
         max_attempts: ${{ inputs.max_attempts }}
         retry_wait_seconds: ${{ inputs.retry_wait_seconds }}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Validate prerelease
         if: github.ref_name == 'main' && inputs.prerelease
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           script: |
             core.setFailed('Do not create a prerelease on "main". You can create a prerelease on a branch and when it is merged it will create a non-prerelease Release. For example: 1.0.1-beta.2 will release as 1.0.1 when merged into main.')
@@ -75,7 +75,7 @@ jobs:
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+        uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
         with:
           git-user-name: ${{ steps.github-user-info.outputs.username }}
           git-user-email: ${{ steps.github-user-info.outputs.email }}
@@ -90,7 +90,7 @@ jobs:
           output-file: ${{ steps.prereleaseTag.outputs.tag && 'false' || 'CHANGELOG.md' }} # If prerelease, do not write the changelog file
 
       - name: Create Github Release
-        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         with:
           name: ${{ steps.changelog.outputs.tag }}

--- a/.github/workflows/devScriptsUpdate.yml
+++ b/.github/workflows/devScriptsUpdate.yml
@@ -21,7 +21,7 @@ jobs:
           version: latest
           npmPackage: "@salesforce/dev-scripts"
       - run: echo "dev scripts latest is ${{ steps.version-info.outputs.version }}"
-      - uses: notiz-dev/github-action-json-property@7a701887f4b568b23eb7b78bb0fc49aaeb1b68d3
+      - uses: salesforcecli/github-workflows/.github/actions/get-json-property@main
         id: packageVersion
         with:
           path: "package.json"

--- a/.github/workflows/externalNut.yml
+++ b/.github/workflows/externalNut.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Cache node modules
         if: inputs.useCache
         id: cache-nodemodules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/githubRelease.yml
+++ b/.github/workflows/githubRelease.yml
@@ -43,14 +43,14 @@ jobs:
 
       - name: prerelease package.json validation
         if: inputs.prerelease && !steps.distTag.outputs.tag
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           script: |
             core.setFailed('Prerelease requires a dist tag name in your package.json like beta in 1.1.1-beta.0')
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@9962c3267b32873dbc552a38a8397194361e1101
+        uses: TriPSs/conventional-changelog-action@3a392e9aa44a72686b0fc13259a90d287dd0877c
         with:
           git-user-name: svc-cli-bot
           git-user-email: svc_cli_bot@salesforce.com

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -70,7 +70,7 @@ jobs:
           cache: yarn
       - name: Cache node modules
         id: cache-nodemodules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/packUploadWindows.yml
+++ b/.github/workflows/packUploadWindows.yml
@@ -37,7 +37,7 @@ jobs:
           cache: yarn
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@41775cf0c82ef066f1eb39cea1bd74697ca5b735
+        uses: Homebrew/actions/setup-homebrew@e05416b42376bcda221f9102c4f595f4994016be
       - run: brew install makensis
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
       - run: yarn pack:win

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
       - name: Cache node modules
         id: cache-nodemodules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -31,7 +31,7 @@ jobs:
           cache: yarn
       - name: Cache node modules
         id: cache-nodemodules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -7,25 +7,25 @@ jobs:
     if: ${{ !contains(github.event.pull_request.body, '[skip-validate-pr]') && !contains(github.event.pull_request.title, '[skip-validate-pr]') }}
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
+      - uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
         id: regex-match-gus-wi
         with:
           text: ${{ github.event.pull_request.body }}
           regex: '@W-\d{7,8}@'
           flags: gm
-      - uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
+      - uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
         id: regex-match-gha-run
         with:
           text: ${{ github.event.pull_request.body }}
           regex: 'https:\/\/github.com\/.*\/actions\/runs\/'
           flags: gm
-      - uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
+      - uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
         id: regex-match-gh-issue
         with:
           text: ${{ github.event.pull_request.body }}
           regex: "#[0-9]+"
           flags: gm
-      - uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
+      - uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
         id: regex-match-cli-gh-issue
         with:
           text: ${{ github.event.pull_request.body }}

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ jobs:
       tag: ${{ steps.distTag.outputs.tag }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag  }}
       - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main


### PR DESCRIPTION
* `actions/checkout`  https://github.com/actions/checkout
    * Was v3
    * **Use v4**
* `actions/setup-node` https://github.com/actions/setup-node
    * Was v3
    * **Use V4**
* `actions/github-script` https://github.com/actions/github-script
    * Was v3
    * **Use V7**
        * I don’t thing there are any breaking changes since we only use this for `core.setFailed`
* `actions/cache` https://github.com/actions/cache
    * Was v3
    * **Use v4**
* `TriPSs/conventional-changelog-action`  https://github.com/TriPSs/conventional-changelog-action/
    * 🟢 Review completed
    * Was `9962c3267b32873dbc552a38a8397194361e1101`
    * Use `3a392e9aa44a72686b0fc13259a90d287dd0877c`
* `notiz-dev/github-action-json-property` https://github.com/notiz-dev/github-action-json-property
    * 🟢 Replaced
    * Was `7a701887f4b568b23eb7b78bb0fc49aaeb1b68d3`
    * Replace with: `salesforcecli/github-workflows/.github/actions/get-json-property@main`
    * 🟠 TODO: Check and replace in `salesforcecli` and `forcedotcom`
        * Of note: [This use](https://github.com/salesforcecli/github-workflows/blob/ccf407c7ea7b866e204dfdec26ce5812bb34cdb6/.github/workflows/devScriptsUpdate.yml#L28) will need to change to `devDependencies["@salesforce/dev-scripts"]`
    * Test workflow: https://github.com/iowillhoit/gha-sandbox/actions/workflows/testing-get-json-property-action.yml
* `booxmedialtd/ws-action-parse-semver` 
    * 🟢 Replaced
    * Was `7784200024d6b3fc01253e617ec0168daf603de3`
    * Replace with: `salesforcecli/github-workflows/.github/actions/parse-semver@main`
    * 🟠 TODO: Check and replace in `salesforcecli` and `forcedotcom`
    * Test workflow: https://github.com/iowillhoit/gha-sandbox/actions/workflows/testing-parse-semver-action.yml
    * Test shell script: https://github.com/iowillhoit/gha-sandbox/blob/main/test-version.sh
* `actions-ecosystem/action-regex-match` https://github.com/actions-ecosystem/action-regex-match
    * 🟢 Replaced
    * Was `d50fd2e7a37d0e617aea3d7ada663bd56862b9cc`
    * Replace with: https://github.com/kaisugi/action-regex-match
        * New fork to replace abandoned action ([see comment](https://github.com/actions-ecosystem/action-regex-match/pull/399#issuecomment-1666777916))
            * Compare 
                * https://github.com/actions-ecosystem/action-regex-match/blob/main/src/main.ts
                * https://github.com/kaisugi/action-regex-match/blob/main/src/index.ts
        * Use `kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8`
    * 🟠 TODO: Check and replace in `salesforcecli` and `forcedotcom`
* `nick-fields/retry` https://github.com/nick-fields/retry
    * 🟢 Replaced
    * Was `943e742917ac94714d2f408a0e8320f2d1fcafcd`
    * Use `3f757583fb1b1f940bc8ef4bf4734c8dc02a5847`
* `ncipollo/release-action` https://github.com/ncipollo/release-action
    * 🟢 Reviewed
    * Was `6c75be85e571768fa31b40abf38de58ba0397db5`
    * Use `2c591bcc8ecdcd2db72b97d6147f871fcd833ba5`
    * 🟠 TODO: Check and replace in `salesforcecli` and `forcedotcom`
* `actions/create-release@v1`
    * ❓ Ignore or deprecate - it is part of a deprecated action
* `google/wireit@setup-github-actions-caching/v1` https://github.com/google/wireit/tree/setup-github-actions-caching
    * 🟢 Ok
* `Homebrew/actions/setup-homebrew` https://github.com/Homebrew/actions/tree/master/setup-homebrew
    * 🟢 Reviewed
    * Was `41775cf0c82ef066f1eb39cea1bd74697ca5b735`
    * Use `e05416b42376bcda221f9102c4f595f4994016be`

