### PR TITLE
Collect info on error

### DIFF
--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -24,7 +24,11 @@ jobs:
         id: ctc
         shell: bash
         run: |
+            # Temp disable exit on error
+            set +e
             CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json)
+            # Re-enable exit on error
+            set -e
 
             STATUS=$(printf '%s' "$CTC_RESULT" | jq -r '.status')
             CTC_ID=$(printf '%s' "$CTC_RESULT" | jq -r '.result.id')


### PR DESCRIPTION
Github Actions sets -e on the shell by default making it exit immediately on an error. 
`shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}`

This prevented us from getting useful error information from an oclif command in GHA. Temporarily setting `+e` allows us to get the error json to parse later. 

Example of this working: https://github.com/iowillhoit/gha-sandbox/actions/runs/9406451924/job/25909919754

[skip-validate-pr]