### PR TITLE
fix: org/repo regex

### DIFF
--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -17,7 +17,7 @@ jobs:
         id: regex-match-gha-run
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: 'https:\/\/github.com\/.*\/actions\/runs\/'
+          regex: 'https:\/\/github\.com\/[\w\.-]+\/[\w\.-]+\/actions\/runs\/'
           flags: gm
       - uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
         id: regex-match-gh-issue


### PR DESCRIPTION
This regex should work for all github org/repo combos (based on [this SO](https://stackoverflow.com/questions/59081778/rules-for-special-characters-in-github-repository-name#comment132563138_59082561))

Example of this working for the vast majority of our repos: https://regex101.com/r/7UUkbm/1

[@W-16027880@](https://gus.lightning.force.com/a07EE00001ugi05YAA)

