### PR TITLE
Exit if already published to npm

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -76,6 +76,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: echo "published said ${{ steps.is-published.outputs.published }}"
 
+  fail-if-published:
+    needs: [check-publish]
+    if: needs.check-publish.outputs.published == 'true'
+    uses: actions/github-script@v7
+    with:
+      script: core.setFailed("The version '${{ inputs.githubTag }}' has already been published to npm")
+
   ctc-open:
     needs: [check-publish]
     if: inputs.ctc && needs.check-publish.outputs.published == 'false'


### PR DESCRIPTION
While attempting to test the `failureNotifications` workflow, I discovered that if an npm version is already published, the workflow just skips the rest of the steps and we don't get a failure notification https://github.com/salesforcecli/testPackageRelease/actions/runs/9471234489

Note this was skipped: https://github.com/salesforcecli/testPackageRelease/actions/runs/9471239334

This will now exit the workflow and should cause the `failureNotification` workflow to run.

Part of [@W-15960060@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15960060)