### PR TITLE
Reject invalid semver

### DIFF
--- a/.github/actions/parse-semver/action.yml
+++ b/.github/actions/parse-semver/action.yml
@@ -34,6 +34,14 @@ runs:
         FULL_VERSION="${{ inputs.input_string }}"
         VERSION="${FULL_VERSION#v}"
 
+        # Filter out non-semver characters
+        CLEAN_VERSION=$(echo "$VERSION" | sed -E 's/[^0-9a-zA-Z.-]+//g')
+
+        if [[ "$CLEAN_VERSION" != "$VERSION" ]]; then
+            echo "Semver version includes invalid characters. Exiting..."
+            exit 1
+        fi
+
         # Split version into parts
         IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 


### PR DESCRIPTION
If semver contains non-semver characters, exit 1. 

[@W-15999558@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15999558)

Example of this failing: https://github.com/iowillhoit/gha-sandbox/actions/runs/9503509788/job/26194090254
Example of this passing: https://github.com/iowillhoit/gha-sandbox/actions/runs/9504810451/job/26198288945