### PR TITLE
fix: allow to skip ts-dep check

### DIFF
--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -1,5 +1,11 @@
 on:
   workflow_call:
+    inputs:
+      skipTsDepCheck:
+        type: boolean
+        required: false
+        default: false
+        description: skip `prevent-typescript-dependency`. Use it for devDeps that ship TS
 
 jobs:
   determine-node-versions:
@@ -14,6 +20,7 @@ jobs:
           nodeDisableCurrent: ${{ vars.UT_DISABLE_NODE_CURRENT }} # default is falsy
 
   prevent-typescript-dependency:
+    if: ${{ inputs.skipTsDepCheck == 'false' }}
     uses: salesforcecli/github-workflows/.github/workflows/preventTypescriptDep.yml@main
 
   linux-unit-tests:


### PR DESCRIPTION
allows to skip the ts-dep-check.

input var, default to `false` and not required so not breaking change.

Tested here (eslint plugin does ship TS, fine b/c it's a devDep): 
https://github.com/salesforcecli/eslint-plugin-sf-plugin/pull/447

https://github.com/salesforcecli/eslint-plugin-sf-plugin/pull/447/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R14

https://github.com/salesforcecli/eslint-plugin-sf-plugin/actions/runs/10097522355/job/27922579850