### PR TITLE
fix(skipTsDepCheck): check boolean, not string

### DIFF
--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -20,7 +20,7 @@ jobs:
           nodeDisableCurrent: ${{ vars.UT_DISABLE_NODE_CURRENT }} # default is falsy
 
   prevent-typescript-dependency:
-    if: ${{ inputs.skipTsDepCheck == 'false' }}
+    if: ${{ inputs.skipTsDepCheck == false }}
     uses: salesforcecli/github-workflows/.github/workflows/preventTypescriptDep.yml@main
 
   linux-unit-tests:


### PR DESCRIPTION
follow up of https://github.com/salesforcecli/github-workflows/pull/120

it was checking boolean values against strings, so all workflows got the ts-dep-check disabled unless the input var with any value was provided.

found here (see ts-dep check didn't run, the workflow didn't specify the input var: 
https://github.com/salesforcecli/plugin-data/pull/1002/commits/932146d1ff9337c2f16c9c46b10cb863e8a5b75e

tested with `input.skipTsDepCheck` false/true here (see bool=true/false commits) here:
https://github.com/salesforcecli/eslint-plugin-sf-plugin/pull/447

and with no input var (should do the check) here:
https://github.com/salesforcecli/plugin-data/pull/1002