### PR TITLE
chore: yarn why typescript

### DIFF
--- a/.github/workflows/preventTypescriptDep.yml
+++ b/.github/workflows/preventTypescriptDep.yml
@@ -12,5 +12,6 @@ jobs:
           yarn install --production
           if [ -d node_modules/typescript ]; then
             echo "Typescript dependency found";
+            yarn why typescript;
             exit 1;
           fi


### PR DESCRIPTION
Run `yarn why typescript` if typescript was found in production node_modules