### PR TITLE
Revert "feat: no ctc for prerelease"

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -83,7 +83,7 @@ jobs:
 
   ctc-open:
     needs: [check-publish]
-    if: inputs.ctc && needs.check-publish.outputs.published == 'false' && inputs.tag == 'latest'
+    if: inputs.ctc && needs.check-publish.outputs.published == 'false'
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
     secrets: inherit
 


### PR DESCRIPTION
I think this is causing npm publish on prereleases to skip

Reverts salesforcecli/github-workflows#122