### PR TITLE
chore: update error output

### DIFF
--- a/.github/workflows/preventTypescriptDep.yml
+++ b/.github/workflows/preventTypescriptDep.yml
@@ -11,7 +11,10 @@ jobs:
       - run: |
           yarn install --production
           if [ -d node_modules/typescript ]; then
-            echo "Typescript dependency found";
+            echo "ERROR: Typescript dependency found";
+            echo "--- yarn why typescript ---"
             yarn why typescript;
+            echo "--- npm ls typescript---"
+            npm ls typescript
             exit 1;
           fi


### PR DESCRIPTION
Run `npm ls typescript` when typescript is found because it often has additional information that `yarn why` doesn't provide