### PR TITLE
W-17811792 - fix: use ubuntu 22 8 core large runner

### DIFF
--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -22,7 +22,7 @@ jobs:
   tarballs:
     env:
       SF_DISABLE_TELEMETRY: true
-    runs-on: ubuntu-20-8core
+    runs-on: ubuntu-22-8core
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
GitHub is deprecating Ubuntu 20 runners.  The only CLI repo that uses Ubuntu 20 is this one so bumping to a new Ubuntu 22 runner.

@W-17811792@