### PR TITLE
W-17239852 Add --test-environment to change case

### DIFF
--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    inputs:
+      githubTag:
+        description: 'The semver tag of the GitHub Release'
+        type: string
     outputs:
       changeCaseId:
         description: Id for the change case created
@@ -26,7 +30,12 @@ jobs:
         run: |
             # Temp disable exit on error
             set +e
-            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --release ${{github.repository}}.$(date +%F) --json)
+            if [ -n "$GITHUB_TAG" ]; then
+              RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/$GITHUB_TAG"
+            else
+              RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases"
+            fi
+            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --test-environment $RELEASE_URL --release ${{github.repository}}.$(date +%F) --json)
             # Re-enable exit on error
             set -e
 
@@ -42,6 +51,7 @@ jobs:
                 exit 1
             fi
         env:
+          GITHUB_TAG: ${{ inputs.githubTag }}
           SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ secrets.SF_CHANGE_CASE_SFDX_AUTH_URL}}
           SF_CHANGE_CASE_TEMPLATE_ID: ${{ secrets.SF_CHANGE_CASE_TEMPLATE_ID}}
           SF_CHANGE_CASE_CONFIGURATION_ITEM: ${{ secrets.SF_CHANGE_CASE_CONFIGURATION_ITEM}}

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -95,6 +95,8 @@ jobs:
     needs: [check-publish]
     if: inputs.ctc && needs.check-publish.outputs.published == 'false'
     uses: salesforcecli/github-workflows/.github/workflows/ctcOpen.yml@main
+    with:
+      githubTag: ${{ inputs.githubTag }}
     secrets: inherit
 
   npm-publish:


### PR DESCRIPTION
Merge this first: https://github.com/forcedotcom/change-case-management/pull/158

Part of the pipeline compliance work. We need to link from the Change Case to where the test were ran.

I chose to link back to the Github Release because it is possible for a Release to contain more than one PR merge. Thanks to our change logs, the links to the PRs are listed in the Github Release body

[@W-17239852@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-17239852)
Also part of [@W-18023620@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18023620)