### PR TITLE
W-18228933 use new wireit cache

### DIFF
--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -65,7 +65,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching#f21db1f3a6a4db31f42787a958cf2a18308effed
+        continue-on-error: true
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -38,8 +38,8 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: yarn
 
-      # - uses: google/wireit@setup-github-actions-caching/v1
-      #   continue-on-error: true
+      - uses: google/wireit@setup-github-actions-caching#f21db1f3a6a4db31f42787a958cf2a18308effed
+        continue-on-error: true
 
       - name: Cache node modules
         id: cache-nodemodules

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -25,8 +25,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # - uses: google/wireit@setup-github-actions-caching/v1
-      #   continue-on-error: true
+      - uses: google/wireit@setup-github-actions-caching#f21db1f3a6a4db31f42787a958cf2a18308effed
+        continue-on-error: true
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
We were affected by this brownout period due to caching methods changing
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

Google fixed this [here](https://github.com/google/wireit/issues/1297#issuecomment-2794737569) 

[@W-18228933@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18228933)