### PR TITLE
W-18302796: update to wire action v2

### DIFF
--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -91,8 +91,11 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
-      - name: Install newest wireit
-        run: yarn add wireit@latest
+      # This is a temporary workaround to ensure wireit is >= 0.14.12
+      # Once all plugins/libs that use this workflow are updated, this can be removed
+      # See: https://github.com/google/wireit/issues/1297#issuecomment-2794737569
+      - name: Install wireit
+        run: yarn add wireit@^0.14.12
 
       - run: yarn compile
 

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -91,6 +91,9 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
+      - name: Install newest wireit
+        run: yarn add wireit@latest
+
       - run: yarn compile
 
       - name: Check that oclif config exists

--- a/.github/workflows/nut.yml
+++ b/.github/workflows/nut.yml
@@ -65,8 +65,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # - uses: google/wireit@setup-github-actions-caching/v2
-      #   continue-on-error: true
+      - uses: google/wireit@setup-github-actions-caching/v2
+        continue-on-error: true
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -38,8 +38,8 @@ jobs:
           node-version: ${{ matrix.node_version }}
           cache: yarn
 
-      # - uses: google/wireit@setup-github-actions-caching/v2
-      #   continue-on-error: true
+      - uses: google/wireit@setup-github-actions-caching/v2
+        continue-on-error: true
 
       - name: Cache node modules
         id: cache-nodemodules

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -53,8 +53,11 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
-      - name: Install newest wireit
-        run: yarn add wireit@latest
+      # This is a temporary workaround to ensure wireit is >= 0.14.12
+      # Once all plugins/libraries that use this workflow are updated, this can be removed
+      # See: https://github.com/google/wireit/issues/1297#issuecomment-2794737569
+      - name: Install wireit
+        run: yarn add wireit@^0.14.12
 
       - run: yarn build
 

--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -53,6 +53,9 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
+      - name: Install newest wireit
+        run: yarn add wireit@latest
+
       - run: yarn build
 
       - name: yarn test

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -45,6 +45,9 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
+      - name: Install newest wireit
+        run: yarn add wireit@latest
+
       - run: yarn build
 
       - name: yarn test

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -25,8 +25,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # - uses: google/wireit@setup-github-actions-caching/v2
-      #   continue-on-error: true
+      - uses: google/wireit@setup-github-actions-caching/v2
+        continue-on-error: true
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -45,8 +45,11 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
-      - name: Install newest wireit
-        run: yarn add wireit@latest
+      # This is a temporary workaround to ensure wireit is >= 0.14.12
+      # Once all plugins/libraries that use this workflow are updated, this can be removed
+      # See: https://github.com/google/wireit/issues/1297#issuecomment-2794737569
+      - name: Install wireit
+        run: yarn add wireit@^0.14.12
 
       - run: yarn build
 


### PR DESCRIPTION
Updates the wireit action to v2
Provides a temp-workaround to ensure that repos have a new-enough local `wireit`.
Proof of this working: https://github.com/salesforcecli/plugin-org/actions/runs/14577349675/job/40886308636

FYI: this was bumped in [dev-scripts here](https://github.com/forcedotcom/dev-scripts/pull/387) 

See [this thread](https://github.com/google/wireit/issues/1297#issuecomment-2794737569) for more details. 

[@W-18302796@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18302796)