### PR TITLE
W-18709286 adds service and test-env

### DIFF
--- a/.github/actions/ctcOpen/action.yml
+++ b/.github/actions/ctcOpen/action.yml
@@ -14,6 +14,9 @@ inputs:
   SVC_CLI_BOT_GITHUB_TOKEN:
     description: Github token
     required: true
+  githubTag:
+    description: 'The semver tag of the GitHub Release'
+    required: false
 
 outputs:
   changeCaseId:
@@ -39,7 +42,12 @@ runs:
       with:
         max_attempts: 5
         command: |
-          CTC_RESULT=$(sfchangecase create --location ${{ github.repositoryUrl }} --release ${{ github.repository }}.$(date +%F) --json)
+          if [ -n "$GITHUB_TAG" ]; then
+            RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/$GITHUB_TAG"
+          else
+            RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases"
+          fi
+          CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --test-environment $RELEASE_URL --service platform-cli --release ${{github.repository}}.$(date +%F) --json)
 
           STATUS=$(printf '%s' "$CTC_RESULT" | jq -r '.status')
           CTC_ID=$(printf '%s' "$CTC_RESULT" | jq -r '.result.id')
@@ -56,6 +64,7 @@ runs:
         SF_CHANGE_CASE_SFDX_AUTH_URL: ${{ inputs.SF_CHANGE_CASE_SFDX_AUTH_URL}}
         SF_CHANGE_CASE_TEMPLATE_ID: ${{ inputs.SF_CHANGE_CASE_TEMPLATE_ID}}
         SF_CHANGE_CASE_CONFIGURATION_ITEM: ${{ inputs.SF_CHANGE_CASE_CONFIGURATION_ITEM}}
+        GITHUB_TAG: ${{ inputs.githubTag }}
 
     - run: echo "[INFO] Change Case ID is:\ $STEPS_CTC_CTCID"
       shell: bash

--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -35,7 +35,7 @@ jobs:
             else
               RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases"
             fi
-            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --test-environment $RELEASE_URL --release ${{github.repository}}.$(date +%F) --json)
+            CTC_RESULT=$(sfchangecase create --location ${{github.repositoryUrl}} --test-environment $RELEASE_URL --service platform-cli --release ${{github.repository}}.$(date +%F) --json)
             # Re-enable exit on error
             set -e
 


### PR DESCRIPTION
Passes in a new flag for you to be able to set the Service__c on a Case

[Proof of this working](https://gus.lightning.force.com/lightning/r/Case/500EE00001XuOp3YAF/view) (search for service)

**Merge after https://github.com/forcedotcom/change-case-management/pull/159**

The test-env is the same changes as https://github.com/salesforcecli/github-workflows/pull/135. I need to add it to the Action because the CLI promotion uses that one.

[@W-18709286@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18709286)