### PR TITLE
chore: remove wireit install workaround W-19407110

### DIFF
--- a/.github/workflows/unitTestsLinux.yml
+++ b/.github/workflows/unitTestsLinux.yml
@@ -53,12 +53,6 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
-      # This is a temporary workaround to ensure wireit is >= 0.14.12
-      # Once all plugins/libraries that use this workflow are updated, this can be removed
-      # See: https://github.com/google/wireit/issues/1297#issuecomment-2794737569
-      - name: Install wireit
-        run: yarn add wireit@^0.14.12
-
       - run: yarn build
 
       - name: yarn test

--- a/.github/workflows/unitTestsWindows.yml
+++ b/.github/workflows/unitTestsWindows.yml
@@ -45,12 +45,6 @@ jobs:
       - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
         if: ${{ steps.cache-nodemodules.outputs.cache-hit != 'true' }}
 
-      # This is a temporary workaround to ensure wireit is >= 0.14.12
-      # Once all plugins/libraries that use this workflow are updated, this can be removed
-      # See: https://github.com/google/wireit/issues/1297#issuecomment-2794737569
-      - name: Install wireit
-        run: yarn add wireit@^0.14.12
-
       - run: yarn build
 
       - name: yarn test


### PR DESCRIPTION
Most of our repos are on the right dev-scripts version with the required wireit:
https://github.com/search?q=org%3Asalesforcecli+%2F%22%5C%40salesforce%5C%2Fdev-scripts%22%3A+%22%2F+lang%3Ajson+NOT+is%3Aarchived&type=code

needed by https://github.com/salesforcecli/mcp/pull/149/

@W-19407110@