### PR TITLE
W-19595600: check for vuln packages

### DIFF
--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -55,6 +55,11 @@ on:
         required: false
         default: yarn
         type: string
+      vulnerabilityCheck:
+        description: if true, checks for known vulnerable package versions
+        required: false
+        default: true
+        type: boolean
 jobs:
   check-publish:
     outputs:
@@ -131,6 +136,66 @@ jobs:
       - name: Install dependencies with npm
         if: inputs.packageManager == 'npm'
         uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+      - name: Vulnerability check
+        if: inputs.vulnerabilityCheck
+        # Temporary check for known vulnerable packages from the following supply chain attack:
+        # https://www.sonatype.com/blog/npm-chalk-and-debug-packages-hit-in-software-supply-chain-attack
+        # Last updated 10:33 a.m. ET on September 9, 2025
+        run: |
+          vulns=(
+            "@coveops/abi@2.0.1"
+            "@duckdb/duckdb-wasm@1.29.2"
+            "@duckdb/node-api@1.3.3"
+            "@duckdb/node-bindings@1.3.3"
+            "ansi-regex@6.2.1"
+            "ansi-styles@6.2.2"
+            "backslash@0.2.1"
+            "chalk@5.6.1"
+            "chalk-template@1.1.1"
+            "color@5.0.1"
+            "color-convert@3.1.1"
+            "color-name@2.0.1"
+            "color-string@2.1.1"
+            "debug@4.4.2"
+            "duckdb@1.3.3"
+            "error-ex@1.3.3"
+            "has-ansi@6.0.1"
+            "is-arrayish@0.3.3"
+            "prebid@10.9.2"
+            "prebid-universal-creative@1.17.3"
+            "prebid.js@10.9.2"
+            "proto-tinker-wc@0.1.87"
+            "simple-swizzle@0.2.3"
+            "slice-ansi@7.1.1"
+            "strip-ansi@7.1.1"
+            "supports-color@10.2.1"
+            "supports-hyperlinks@4.1.1"
+            "wrap-ansi@9.0.1"
+          )
+
+          for vuln in "${vulns[@]}"; do
+            if [[ -n $(npm ls --depth=99 --parseable "$vuln") ]]; then
+              echo "VULNERABILITY FOUND: $vuln"
+              exit 1
+            else
+              echo "Known vulnerability not found: $vuln"
+            fi
+          done
+
+          # Known string from the exploit
+          # https://github.com/chalk/chalk/issues/656#issuecomment-3266880534
+          strings=(
+            "_0x112fa8"
+          )
+
+          for str in "${strings[@]}"; do
+            if grep -r "$str" --include='*.js' .; then
+              echo "VULNERABILITY FOUND: string '$str' found in js files"
+              exit 1
+            else
+              echo "String '$str' not found in js files"
+            fi
+          done
       - run: $INPUTS_PACKAGE_MANAGER run build
       - run: npm install -g @salesforce/plugin-release-management
       - name: NPM Release


### PR DESCRIPTION
Adds a temporary check for vulnerable npm packages from a recent supply chain attack
https://www.sonatype.com/blog/npm-chalk-and-debug-packages-hit-in-software-supply-chain-attack

[@W-19595600@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-19595600)

Spoofed examples of this working
<img width="1782" height="1042" alt="Screenshot 2025-09-09 at 2 59 02 PM" src="https://github.com/user-attachments/assets/067c7c77-448f-412a-bba2-10705e7fcf09" />

<img width="2458" height="714" alt="Screenshot 2025-09-09 at 2 58 54 PM" src="https://github.com/user-attachments/assets/e9b9dbd4-ac19-4235-b15a-44ef683873d0" />
