### PR TITLE
fix: handle no-op case-W-22406465

### DIFF
--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -45,6 +45,5 @@ jobs:
         run: |
           cd docs
           git add .
-          git diff --cached --quiet && echo "No docs changes to publish" && exit 0
-          git commit -m 'docs: publishing gh-pages [skip ci]' --no-verify
+          git diff --cached --quiet || git commit -m 'docs: publishing gh-pages [skip ci]' --no-verify
           git push origin gh-pages --no-verify

--- a/.github/workflows/publishTypedoc.yml
+++ b/.github/workflows/publishTypedoc.yml
@@ -45,5 +45,6 @@ jobs:
         run: |
           cd docs
           git add .
+          git diff --cached --quiet && echo "No docs changes to publish" && exit 0
           git commit -m 'docs: publishing gh-pages [skip ci]' --no-verify
           git push origin gh-pages --no-verify


### PR DESCRIPTION
Add `git diff --cached --quiet `check before the commit. If nothing is staged, the step exits 0 cleanly and skip the commit and push.

@W-22406465@