### PR TITLE
fix: remove npm cache from CTC workflows to support pnpm/yarn repos

### DIFF
--- a/.github/workflows/ctcClose.yml
+++ b/.github/workflows/ctcClose.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
+          # No `cache: npm`: it requires an npm lockfile and so hard-fails on
+          # pnpm/yarn consumer repos; the CTC CLI below is a one-off global install.
       - run: npm install -g @salesforce/change-case-management --omit=dev
       - id: ctc
         run: |

--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          cache: npm
+          # No `cache: npm`: it requires an npm lockfile and so hard-fails on
+          # pnpm/yarn consumer repos; the CTC CLI below is a one-off global install.
 
       - run: npm install -g @salesforce/change-case-management --omit=dev
 


### PR DESCRIPTION
## What

Remove `cache: npm` from the `actions/setup-node` step in `ctcOpen.yml` and `ctcClose.yml`.

## Why

`cache: npm` requires an npm lockfile (`package-lock.json` / `npm-shrinkwrap.json`) to compute its cache key. Consumer repos that use **pnpm** or **yarn** don't have one, so `actions/setup-node` fails with `Dependencies lock file is not found` and the CTC job dies before `sfchangecase` ever runs.

The only npm operation in these jobs is the one-off global install:

```
npm install -g @salesforce/change-case-management --omit=dev
```

setup-node's npm cache keys on the *consumer repo's* lockfile, not the CTC CLI's deps, so it provides no real benefit here even for npm repos. Dropping it makes the CTC legs work for npm, yarn, and pnpm consumers alike. A short comment is left in place of the removed line so the cache isn't accidentally reintroduced.

## Impact

- **npm consumers:** no behavior change — the cache was effectively dead weight for a global install.
- **pnpm / yarn consumers:** `ctcOpen` / `ctcClose` now run without having to commit a throwaway npm lockfile.

## Context

Surfaced by [`forcedotcom/salesforcedx-vscode-einstein-gpt`](https://github.com/forcedotcom/salesforcedx-vscode-einstein-gpt) (pnpm-only). Its real (non-dry-run) publish failed at the `ctc-open` step — e.g. [this run](https://github.com/forcedotcom/salesforcedx-vscode-einstein-gpt/actions/runs/27067611534/job/79892385683). As a stopgap that repo vendored byte-faithful copies of these two workflows with `cache: npm` dropped; this upstream fix lets it delete the vendored copies and go back to consuming the reusable workflows by SHA.