### PR TITLE
@W-23253606: allow passing node version into ctcOpen action

### DIFF
--- a/.github/actions/ctcOpen/action.yml
+++ b/.github/actions/ctcOpen/action.yml
@@ -17,6 +17,10 @@ inputs:
   githubTag:
     description: 'The semver tag of the GitHub Release'
     required: false
+  nodeVersion:
+    description: version of node to use.  It's better to specify latest, lts/* or lts/-1 than to hardcode numbers
+    required: false
+    default: lts/*
 
 outputs:
   changeCaseId:
@@ -30,7 +34,7 @@ runs:
 
     - uses: actions/setup-node@v4
       with:
-        node-version: lts/*
+        node-version: ${{ inputs.nodeVersion }}
         cache: npm
 
     - run: npm install -g @salesforce/change-case-management --omit=dev


### PR DESCRIPTION
### What does this PR do?
Adds a `nodeVersion` input to the ctcOpen composite action (defaults to `lts/*`), allowing callers to override the node version used for CTC operations.

This is the action counterpart to the workflow change in #160.

### What issues does this PR fix or reference?
[@W-23253606@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23253606)