### PR TITLE
feat: validate-pr workflow now enforces proper commit formatting @W-23251216@

### DIFF
--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -5,20 +5,20 @@ jobs:
     if: ${{ !contains(github.event.pull_request.body, '[skip-validate-pr]') && !contains(github.event.pull_request.title, '[skip-validate-pr]') }}
     runs-on: "ubuntu-latest"
     steps:
-      - name: Find GUS Work Item in Title
+      - name: Validate Pull Request Title
         uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
-        id: regex-match-gus-wi-title
+        id: regex-match-pr-title
         with:
           text: ${{ github.event.pull_request.title }}
-          regex: 'W-\d{7,8}'
+          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\s?(\(.+\))?: .+ \(W-\d{7,}\)$'
           flags: gmi
 
-      - name: Find GUS Work Item in Body
+      - name: Validate Pull Request Body
         uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
         id: regex-match-gus-wi-body
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: '@W-\d{7,8}@'
+          regex: '@W-\d{7,}@'
           flags: gmi
 
       # Disabling GHA Run and Github Issue (for now) due to E360 lookup
@@ -43,10 +43,12 @@ jobs:
         if: |
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
-          (steps.regex-match-gus-wi-title.outputs.match == '' || steps.regex-match-gus-wi-body.outputs.match == '')
+          (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-gus-wi-body.outputs.match == '')
         run: |
-          echo "::warning::PRs need to reference a GUS Work Item in both the PR title AND body. More details in the logs above.
-          - PR titles should start with a Work Item followed by a description, ex: W-12345678: My PR title
+          echo "::warning::PR titles and bodies must meet the specified criteria. More details in the logs above.
+          - PR titles should be of the format \'<type>(<optional-scope>): <description> (W-XXXXXXXX)\',
+            where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+            ex: feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)
           - PR bodies must include a Work Item wrapped in @s, ex: @W-12345678@ or [@W-12345678@](https://some-url)
           - If you absolutely must skip this validation, add [skip-validate-pr] to the PR title or body"
           exit 1

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Validate Pull Request Title
-        uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
+        uses: kaisugi/action-regex-match@main
         id: regex-match-pr-title
         with:
           text: ${{ github.event.pull_request.title }}
@@ -14,12 +14,20 @@ jobs:
           flags: gmi
 
       - name: Validate Pull Request Body
-        uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
+        uses: kaisugi/action-regex-match@main
         id: regex-match-pr-body
         with:
           text: ${{ github.event.pull_request.body }}
           regex: '@W-\d{7,}@'
           flags: gmi
+
+      - name: echo match parts to double-check expectations
+        run: |
+          echo "title match: '${{ steps.regex-match-pr-title.outputs.match }}'"
+          echo "title group1: '${{ steps.regex-match-pr-title.outputs.group1 }}'"
+          echo "title group2: '${{ steps.regex-match-pr-title.outputs.group2 }}'"
+          echo "title group3: '${{ steps.regex-match-pr-title.outputs.group3 }}'"
+          echo "body match: '${{ steps.regex-match-pr-body.outputs.match }}'"
 
       # Disabling GHA Run and Github Issue (for now) due to E360 lookup
 
@@ -45,9 +53,11 @@ jobs:
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
           (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
         run: |
-          [[ '${{ steps.regex-match-pr-title.outputs.match }}' == '' ]] && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
-          [[ '${{ steps.regex-match-pr-body.outputs.match }}' == '' ]] && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
+          [[ '${{ steps.regex-match-pr-title.outputs.match }}' != '' ]] && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
+          [[ '${{ steps.regex-match-pr-body.outputs.match }}' != '' ]] && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
           echo "::warning::PR titles and bodies must meet the specified criteria.
+          - PR should be of the format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
+            where 
           - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
             where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
             e.g., feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Validate Pull Request Body
         uses: kaisugi/action-regex-match@45cc5bacf016a4c0d2c3c9d0f8b7c2f1b79687b8
-        id: regex-match-gus-wi-body
+        id: regex-match-pr-body
         with:
           text: ${{ github.event.pull_request.body }}
           regex: '@W-\d{7,}@'
@@ -43,11 +43,13 @@ jobs:
         if: |
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
-          (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-gus-wi-body.outputs.match == '')
+          (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
         run: |
-          MSG="PR title and body must match specified criteria"
-          [[ true ]] && TITLE_MET=$'\u2714' || TITLE_MET=NO
-          MSG="$MSG+
-          - [$TITLE_MET] REQUIREMENTS FOR TITLE"
-          echo "::warning::$MSG"
+          ${{ steps.regex-match-pr-title.outputs.match }} == '' && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
+          ${{ steps.regex-match-pr-body.outputs.match }} == '' && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
+          echo "::warning::PR titles and bodies must meet the specified criteria:
+          - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
+            where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+            e.g., feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)
+          - [$BODY_STATE] PR body must include a Work Item wrapped in @'s, ex: @W-12345678@ or [@W-12345678@](https://some-url)
           exit 1

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -5,29 +5,44 @@ jobs:
     if: ${{ !contains(github.event.pull_request.body, '[skip-validate-pr]') && !contains(github.event.pull_request.title, '[skip-validate-pr]') }}
     runs-on: "ubuntu-latest"
     steps:
-      - name: Validate Pull Request Title
+      - name: Validate Overall PR Shape
         uses: kaisugi/action-regex-match@main
-        id: regex-match-pr-title
+        id: pr-title-shape-regex
         with:
           text: ${{ github.event.pull_request.title }}
-          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\s?(\(.+\))?: .+ (\(W-\d{7,}\))$'
+          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\s?(\(.+\))?: .+ \((W-\d{7,})\)$'
+          flags: gmi
+
+      - name: Check Title for type
+        uses: kaisugi/action-regex-match@main
+        id: pr-title-type-subportion-regex
+        with:
+          text: ${{ github.event.pull_request.title }}
+          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)'
+          flags: gmi
+
+      - name: Check Title for Work Item
+        uses: kaisugi/action-regex-match@main
+        id: pr-title-work-item-subportion-regex
+        with:
+          text: ${{ github.event.pull_request.title }}
+          regex: ' \((W-\d{7,})\)$'
           flags: gmi
 
       - name: Validate Pull Request Body
         uses: kaisugi/action-regex-match@main
-        id: regex-match-pr-body
+        id: pr-body-work-item-subportion-regex
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: '@W-\d{7,}@'
+          regex: '@(${{ steps.pr-title-work-item-subportion-regex }})@'
           flags: gmi
 
       - name: echo match parts to double-check expectations
         run: |
-          echo "title match: '${{ steps.regex-match-pr-title.outputs.match }}'"
-          echo "title group1: '${{ steps.regex-match-pr-title.outputs.group1 }}'"
-          echo "title group2: '${{ steps.regex-match-pr-title.outputs.group2 }}'"
-          echo "title group3: '${{ steps.regex-match-pr-title.outputs.group3 }}'"
-          echo "body match: '${{ steps.regex-match-pr-body.outputs.match }}'"
+          echo "title shape match: '${{ steps. pr-title-shape-regex.match }}'"
+          echo "title type match: '${{ steps.pr-title-type-subportion-regex.outputs.match }}'"
+          echo "title work item match: '${{ steps.pr-title-work-item-subportion-regex.outputs.match }}'"
+          echo "body work itme match: '${{ steps.pr-body-work-item-subportion-regex.outputs.match }}'"
 
       # Disabling GHA Run and Github Issue (for now) due to E360 lookup
 
@@ -51,15 +66,24 @@ jobs:
         if: |
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
-          (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
+          (steps.pr-title-shape-regex.outputs.match == '' || steps.pr-body-work-item-subportion-regex.outputs.match == '')
         run: |
-          [[ '${{ steps.regex-match-pr-title.outputs.match }}' != '' ]] && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
-          [[ '${{ steps.regex-match-pr-body.outputs.match }}' != '' ]] && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
+          # Define a checkmark and an x-mark as variables.
+          PASS=$'\u2714'
+          FAIL=$'\u2715'
+          
+          # Determine which criteria were and were not met based on the outputs we captured
+          [[ '${{ steps.pr-title-shape-regex.outputs.match }}' == '' ]] && TITLE_SHAPE=$FAIL || TITLE_SHAPE=$PASS
+          [[ '${{ steps.pr-title-type-subportion-regex.outputs.match }}' == '' ]] && TITLE_TYPE=$FAIL || TITLE_TYPE=$PASS
+          [[ '${{ steps.pr-title-work-item-subportion-regex.outputs.match }}' == '' ]] && TITLE_WORK_ITEM=$FAIL || TITLE_WORK_ITEM=$PASS
+          [[ '${{ steps.pr-body-work-item-subportion-regex.outputs.match }}' == '' ]] && BODY_WORK_ITEM=$FAIL || BODY_WORK_ITEM=$PASS
+          
+          # Output the criteria summary
           echo "::warning::PR titles and bodies must meet the specified criteria.
-          - PR should be of the format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
-            where 
-          - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
-            where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
-            e.g., feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)
-          - [$BODY_STATE] PR body must include a Work Item wrapped in @'s, ex: @W-12345678@ or [@W-12345678@](https://some-url)"
+          - [$TITLE_SHAPE] PR title must be well-formed (i.e., match '<type>(<optional-scope>): <description> (W-XXXXXXX)')
+            (example: feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345678)
+            - [$TITLE_TYPE] <type> subportion must be one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+            - [$TITLE_WORK_ITEM] Must end with work item number wrapped in parentheses
+          - [$BODY_WORK_ITEM] PR body must include work item from title, wrapped in '@'s, ex: @W-1234567@ or [@W-1234567](https://some-url)
+          If you ABSOLUTELY MUST bypass these validations, include '[skip-validate-pr]' in the PR title or body"
           exit 1

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -45,8 +45,8 @@ jobs:
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
           (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
         run: |
-          '${{ steps.regex-match-pr-title.outputs.match }}' == '' && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
-          '${{ steps.regex-match-pr-body.outputs.match }}' == '' && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
+          [[ '${{ steps.regex-match-pr-title.outputs.match }}' == '' ]] && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
+          [[ '${{ steps.regex-match-pr-body.outputs.match }}' == '' ]] && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
           echo "::warning::PR titles and bodies must meet the specified criteria:
           - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
             where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -42,7 +42,7 @@ jobs:
           echo "title shape match: '${{ steps.pr-title-shape-regex.outputs.match }}'"
           echo "title type match: '${{ steps.pr-title-type-subportion-regex.outputs.match }}'"
           echo "title work item match: '${{ steps.pr-title-work-item-subportion-regex.outputs.match }}'"
-          echo "body work itme match: '${{ steps.pr-body-work-item-subportion-regex.outputs.match }}'"
+          echo "body work item match: '${{ steps.pr-body-work-item-subportion-regex.outputs.match }}'"
 
       # Disabling GHA Run and Github Issue (for now) due to E360 lookup
 

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: echo match parts to double-check expectations
         run: |
-          echo "title shape match: '${{ steps.pr-title-shape-regex.match }}'"
+          echo "title shape match: '${{ steps.pr-title-shape-regex.outputs.match }}'"
           echo "title type match: '${{ steps.pr-title-type-subportion-regex.outputs.match }}'"
           echo "title work item match: '${{ steps.pr-title-work-item-subportion-regex.outputs.match }}'"
           echo "body work itme match: '${{ steps.pr-body-work-item-subportion-regex.outputs.match }}'"

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -44,8 +44,6 @@ jobs:
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
           (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
-        env:
-          TITLE_MATCH: ${{
         run: |
           [[ '${{ steps.regex-match-pr-title.outputs.match }}' == '' ]] && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
           [[ '${{ steps.regex-match-pr-body.outputs.match }}' == '' ]] && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -45,8 +45,8 @@ jobs:
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
           (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
         run: |
-          ${{ steps.regex-match-pr-title.outputs.match }} == '' && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
-          ${{ steps.regex-match-pr-body.outputs.match }} == '' && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
+          '${{ steps.regex-match-pr-title.outputs.match }}' == '' && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
+          '${{ steps.regex-match-pr-body.outputs.match }}' == '' && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
           echo "::warning::PR titles and bodies must meet the specified criteria:
           - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
             where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -44,10 +44,12 @@ jobs:
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
           (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-pr-body.outputs.match == '')
+        env:
+          TITLE_MATCH: ${{
         run: |
           [[ '${{ steps.regex-match-pr-title.outputs.match }}' == '' ]] && TITLE_STATE=$'\u2714' || TITLE_STATE=$'\u2715'
           [[ '${{ steps.regex-match-pr-body.outputs.match }}' == '' ]] && BODY_STATE=$'\u2714' || BODY_STATE=$'\u2715'
-          echo "::warning::PR titles and bodies must meet the specified criteria:
+          echo "::warning::PR titles and bodies must meet the specified criteria.
           - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
             where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
             e.g., feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: echo match parts to double-check expectations
         run: |
-          echo "title shape match: '${{ steps. pr-title-shape-regex.match }}'"
+          echo "title shape match: '${{ steps.pr-title-shape-regex.match }}'"
           echo "title type match: '${{ steps.pr-title-type-subportion-regex.outputs.match }}'"
           echo "title work item match: '${{ steps.pr-title-work-item-subportion-regex.outputs.match }}'"
           echo "body work itme match: '${{ steps.pr-body-work-item-subportion-regex.outputs.match }}'"

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -39,17 +39,15 @@ jobs:
       #     regex: 'forcedotcom\/cli\/issues\/[0-9]+|forcedotcom\/salesforcedx-vscode\/issues\/[0-9]+'
       #     flags: gm
 
-      - name: Fail if no Work Item references
+      - name: Fail if format requirements not met
         if: |
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           (github.event.pull_request.user.login != 'SF-CLI-BOT' || github.event.pull_request.user.login != 'svc-cli-bot') &&
           (steps.regex-match-pr-title.outputs.match == '' || steps.regex-match-gus-wi-body.outputs.match == '')
         run: |
-          echo "::warning::PR titles and bodies must meet the specified criteria. More details in the logs above.
-          - PR titles should be of the format \'<type>(<optional-scope>): <description> (W-XXXXXXXX)\',
-            where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
-            ex: feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)
-          - PR bodies must include a Work Item wrapped in @s, ex: @W-12345678@ or [@W-12345678@](https://some-url)
-          - If you absolutely must skip this validation, add [skip-validate-pr] to the PR title or body"
+          MSG="PR title and body must match specified criteria"
+          [[ true ]] && TITLE_MET=$'\u2714' || TITLE_MET=NO
+          MSG="$MSG+
+          - [$TITLE_MET] REQUIREMENTS FOR TITLE"
+          echo "::warning::$MSG"
           exit 1
-

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -34,7 +34,7 @@ jobs:
         id: pr-body-work-item-subportion-regex
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: '@(${{ steps.pr-title-work-item-subportion-regex }})@'
+          regex: '@(${{ steps.pr-title-work-item-subportion-regex.outputs.match }})@'
           flags: gmi
 
       - name: echo match parts to double-check expectations

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -53,5 +53,5 @@ jobs:
           - [$TITLE_STATE] PR title should be of format '<type>(<optional-scope>): <description> (W-XXXXXXX)'
             where <type> is one of: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
             e.g., feat: add Angular template support (W-12345678); fix(auth): resolve token refresh issue (W-12345679)
-          - [$BODY_STATE] PR body must include a Work Item wrapped in @'s, ex: @W-12345678@ or [@W-12345678@](https://some-url)
+          - [$BODY_STATE] PR body must include a Work Item wrapped in @'s, ex: @W-12345678@ or [@W-12345678@](https://some-url)"
           exit 1

--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -10,7 +10,7 @@ jobs:
         id: regex-match-pr-title
         with:
           text: ${{ github.event.pull_request.title }}
-          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\s?(\(.+\))?: .+ \(W-\d{7,}\)$'
+          regex: '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\s?(\(.+\))?: .+ (\(W-\d{7,}\))$'
           flags: gmi
 
       - name: Validate Pull Request Body


### PR DESCRIPTION
Previously, the `validate-pr` workflow only checked that a Pull Request's title and body both contained a string that looked like it could conceivably be a GUS work item (i.e., `W-\d{7,8}` in title, and `@W-\d{7,8}@` in body).

Now, the workflow enforces multiple things:
1. The Title matches the following format: `<type> (<optional-scope>): <description> (W-XXXXXXX)`
where `<type>` is one of: `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
2. The Body contains the same work item from the Title, wrapped in @'s.
3. If these criteria are violated, a pretty little criteria tree is logged with checks and x's to show what you did wrong.

This enhancement was done for @W-23251216@.

(all of the testing I did against this was done using [this PR](https://github.com/salesforcecli/testPackageRelease/pull/61) in `testPackageRelease`, and you can check the action execution history [here](https://github.com/salesforcecli/testPackageRelease/actions/workflows/validate-pr.yml?query=branch%3Ajf%2FW-23251216-exp++) to see me finally get to ones that work properly.