### PR TITLE
feat: add prerelease VSIX validation step

### DIFF
--- a/.github/workflows/vscode-package.yml
+++ b/.github/workflows/vscode-package.yml
@@ -172,6 +172,53 @@ jobs:
           echo "checksums_generated=true" >> $GITHUB_OUTPUT
           echo "checksums_file=$EXTENSIONS_ROOT/checksums.json" >> $GITHUB_OUTPUT
 
+      - name: Validate prerelease VSIXs
+        if: inputs.pre-release == 'true'
+        env:
+          EXTENSIONS_ROOT: ${{ inputs.extensions-root || 'packages' }}
+        run: |
+          echo "Validating that VSIXs are marked as prerelease..."
+
+          VSIX_FILES=$(find "$EXTENSIONS_ROOT" -name "*.vsix" -type f)
+
+          if [ -z "$VSIX_FILES" ]; then
+            echo "⚠️ No VSIX files found to validate"
+            exit 0
+          fi
+
+          VALIDATION_FAILED=false
+
+          while IFS= read -r vsix_file; do
+            # Extract package.json from VSIX (it's a zip file)
+            TEMP_DIR=$(mktemp -d)
+            unzip -q "$vsix_file" "extension/package.json" -d "$TEMP_DIR" 2>/dev/null || {
+              echo "⚠️ Could not extract package.json from $(basename "$vsix_file")"
+              rm -rf "$TEMP_DIR"
+              continue
+            }
+
+            # Check if preRelease flag is true in the manifest
+            IS_PRERELEASE=$(jq -r '.version as $v | if $v | test("-pre") then true else false end' "$TEMP_DIR/extension/package.json")
+
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              echo "✅ $(basename "$vsix_file") - correctly marked as prerelease"
+            else
+              echo "❌ $(basename "$vsix_file") - NOT marked as prerelease (missing -pre suffix or flag)"
+              VALIDATION_FAILED=true
+            fi
+
+            rm -rf "$TEMP_DIR"
+          done <<< "$VSIX_FILES"
+
+          if [ "$VALIDATION_FAILED" = "true" ]; then
+            echo ""
+            echo "❌ Validation failed: Some VSIXs are not properly marked as prerelease"
+            echo "   Ensure --pre-release flag is passed to vsce package command"
+            exit 1
+          fi
+
+          echo "✅ All VSIXs validated as prerelease"
+
       - name: Calculate artifact name
         id: calc-artifact-name
         run: |

--- a/.github/workflows/vscode-package.yml
+++ b/.github/workflows/vscode-package.yml
@@ -171,15 +171,17 @@ jobs:
 
           echo "checksums_generated=true" >> $GITHUB_OUTPUT
           echo "checksums_file=$EXTENSIONS_ROOT/checksums.json" >> $GITHUB_OUTPUT
+          # Cache VSIX file list for reuse in validation step
+          echo "vsix_files<<EOF" >> $GITHUB_OUTPUT
+          echo "$VSIX_FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Validate prerelease VSIXs
         if: inputs.pre-release == 'true'
         env:
-          EXTENSIONS_ROOT: ${{ inputs.extensions-root || 'packages' }}
+          VSIX_FILES: ${{ steps.md5-checksums.outputs.vsix_files }}
         run: |
           echo "Validating that VSIXs are marked as prerelease..."
-
-          VSIX_FILES=$(find "$EXTENSIONS_ROOT" -name "*.vsix" -type f)
 
           if [ -z "$VSIX_FILES" ]; then
             echo "⚠️ No VSIX files found to validate"
@@ -189,25 +191,17 @@ jobs:
           VALIDATION_FAILED=false
 
           while IFS= read -r vsix_file; do
-            # Extract package.json from VSIX (it's a zip file)
-            TEMP_DIR=$(mktemp -d)
-            unzip -q "$vsix_file" "extension/package.json" -d "$TEMP_DIR" 2>/dev/null || {
-              echo "⚠️ Could not extract package.json from $(basename "$vsix_file")"
-              rm -rf "$TEMP_DIR"
-              continue
-            }
-
-            # Check if preRelease flag is true in the manifest
-            IS_PRERELEASE=$(jq -r '.version as $v | if $v | test("-pre") then true else false end' "$TEMP_DIR/extension/package.json")
+            # Check if preRelease flag is set in the VSIX manifest
+            # Using unzip -p to pipe directly to grep (no temp directory needed)
+            IS_PRERELEASE=$(unzip -p "$vsix_file" extension.vsixmanifest 2>/dev/null | \
+              { grep -q 'Microsoft.VisualStudio.Code.PreRelease" Value="true"' && echo true || echo false; })
 
             if [ "$IS_PRERELEASE" = "true" ]; then
               echo "✅ $(basename "$vsix_file") - correctly marked as prerelease"
             else
-              echo "❌ $(basename "$vsix_file") - NOT marked as prerelease (missing -pre suffix or flag)"
+              echo "❌ $(basename "$vsix_file") - NOT marked as prerelease (missing PreRelease flag in manifest)"
               VALIDATION_FAILED=true
             fi
-
-            rm -rf "$TEMP_DIR"
           done <<< "$VSIX_FILES"
 
           if [ "$VALIDATION_FAILED" = "true" ]; then

--- a/.github/workflows/vscode-package.yml
+++ b/.github/workflows/vscode-package.yml
@@ -184,7 +184,7 @@ jobs:
           echo "Validating that VSIXs are marked as prerelease..."
 
           if [ -z "$VSIX_FILES" ]; then
-            echo "⚠️ No VSIX files found to validate"
+            echo "No VSIX files found to validate"
             exit 0
           fi
 
@@ -193,25 +193,22 @@ jobs:
           while IFS= read -r vsix_file; do
             # Check if preRelease flag is set in the VSIX manifest
             # Using unzip -p to pipe directly to grep (no temp directory needed)
-            IS_PRERELEASE=$(unzip -p "$vsix_file" extension.vsixmanifest 2>/dev/null | \
-              { grep -q 'Microsoft.VisualStudio.Code.PreRelease" Value="true"' && echo true || echo false; })
-
-            if [ "$IS_PRERELEASE" = "true" ]; then
-              echo "✅ $(basename "$vsix_file") - correctly marked as prerelease"
+            if unzip -p "$vsix_file" extension.vsixmanifest 2>/dev/null | grep -q 'Microsoft.VisualStudio.Code.PreRelease" Value="true"'; then
+              echo "PASS: $(basename "$vsix_file") - correctly marked as prerelease"
             else
-              echo "❌ $(basename "$vsix_file") - NOT marked as prerelease (missing PreRelease flag in manifest)"
+              echo "FAIL: $(basename "$vsix_file") - NOT marked as prerelease (missing PreRelease flag in manifest)"
               VALIDATION_FAILED=true
             fi
           done <<< "$VSIX_FILES"
 
           if [ "$VALIDATION_FAILED" = "true" ]; then
             echo ""
-            echo "❌ Validation failed: Some VSIXs are not properly marked as prerelease"
-            echo "   Ensure --pre-release flag is passed to vsce package command"
+            echo "Validation failed: Some VSIXs are not properly marked as prerelease"
+            echo "Ensure --pre-release flag is passed to vsce package command"
             exit 1
           fi
 
-          echo "✅ All VSIXs validated as prerelease"
+          echo "All VSIXs validated as prerelease"
 
       - name: Calculate artifact name
         id: calc-artifact-name


### PR DESCRIPTION
Addresses PR review high priority item #4:

- Validates VSIXs are marked as prerelease when pre-release: true
- Checks extension.vsixmanifest for Microsoft.VisualStudio.Code.PreRelease flag
- Fails build if any VSIX is not properly marked
- Only runs validation when pre-release input is true
- Reuses VSIX file list from checksum step for efficiency

This ensures the --pre-release flag was properly passed to vsce package command.
