### PR TITLE
fix: resolve 'changed'/'all' extensions in downstream publish jobs

### DIFF
--- a/.github/workflows/vscode-publish-extensions.yml
+++ b/.github/workflows/vscode-publish-extensions.yml
@@ -549,7 +549,7 @@ jobs:
       extensions-root: ${{ inputs.extensions-root || 'packages' }}
 
   determine-publish-matrix:
-    needs: [calculate-artifact-name]
+    needs: [determine-changes, calculate-artifact-name]
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
@@ -569,7 +569,7 @@ jobs:
         id: matrix
         env:
           REGISTRIES: ${{ inputs.registries }}
-          SELECTED_EXTENSIONS: ${{ inputs.extensions }}
+          SELECTED_EXTENSIONS: ${{ needs.determine-changes.outputs.selected-extensions }}
           IS_NIGHTLY: 'true'
           EXTENSIONS_ROOT: ${{ inputs.extensions-root || 'packages' }}
         run: |
@@ -785,9 +785,9 @@ jobs:
 
   create-github-releases:
     name: Create GitHub Releases
-    needs: [package, calculate-artifact-name]
+    needs: [determine-changes, package, calculate-artifact-name]
     runs-on: ubuntu-latest
-    if: needs.package.result == 'success' && inputs.extensions != '' && github.event_name != 'pull_request'
+    if: needs.package.result == 'success' && needs.determine-changes.outputs.selected-extensions != '' && github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -813,7 +813,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          SELECTED_EXTENSIONS: ${{ inputs.extensions }}
+          SELECTED_EXTENSIONS: ${{ needs.determine-changes.outputs.selected-extensions }}
           IS_NIGHTLY: 'true'
           PRE_RELEASE: 'true'
           VERSION_BUMP: ${{ inputs.version-bump }}
@@ -972,7 +972,7 @@ jobs:
   slack-notify:
     name: Slack Notification
     needs:
-      [bump-versions, package, publish, publish-skipped-notice]
+      [determine-changes, bump-versions, package, publish, publish-skipped-notice]
     runs-on: ubuntu-latest
     if: always() && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
     steps:
@@ -987,7 +987,7 @@ jobs:
           EXTENSIONS_ROOT: ${{ inputs.extensions-root || 'packages' }}
         run: |
           # Get selected extensions and their details
-          SELECTED_EXTENSIONS="${{ inputs.extensions }}"
+          SELECTED_EXTENSIONS="${{ needs.determine-changes.outputs.selected-extensions }}"
           VERSION_BUMP="${{ inputs.version-bump }}"
           PRE_RELEASE="true"
 
@@ -1003,7 +1003,7 @@ jobs:
               PACKAGE_NAME=$(node -p "require('./$EXTENSIONS_ROOT/$ext/package.json').name")
               PACKAGE_VERSION=$(node -p "require('./$EXTENSIONS_ROOT/$ext/package.json').version")
               DISPLAY_NAME=$(node -p "require('./$EXTENSIONS_ROOT/$ext/package.json').displayName || require('./$EXTENSIONS_ROOT/$ext/package.json').name")
-              
+
               # Add to arrays
               if [ -z "$EXTENSION_NAMES" ]; then
                 EXTENSION_NAMES="$PACKAGE_NAME"
@@ -1098,7 +1098,7 @@ jobs:
   slack-notify-failure:
     name: Slack Failure Notification
     needs:
-      [bump-versions, package, publish, publish-skipped-notice]
+      [determine-changes, bump-versions, package, publish, publish-skipped-notice]
     runs-on: ubuntu-latest
     if: always() && (needs.publish.result == 'failure' || needs.bump-versions.result == 'failure' || needs.package.result == 'failure')
     steps:
@@ -1113,7 +1113,7 @@ jobs:
           EXTENSIONS_ROOT: ${{ inputs.extensions-root || 'packages' }}
         run: |
           # Get selected extensions and their details
-          SELECTED_EXTENSIONS="${{ inputs.extensions }}"
+          SELECTED_EXTENSIONS="${{ needs.determine-changes.outputs.selected-extensions }}"
           VERSION_BUMP="${{ inputs.version-bump }}"
           PRE_RELEASE="true"
 
@@ -1129,7 +1129,7 @@ jobs:
               PACKAGE_NAME=$(node -p "require('./$EXTENSIONS_ROOT/$ext/package.json').name")
               PACKAGE_VERSION=$(node -p "require('./$EXTENSIONS_ROOT/$ext/package.json').version")
               DISPLAY_NAME=$(node -p "require('./$EXTENSIONS_ROOT/$ext/package.json').displayName || require('./$EXTENSIONS_ROOT/$ext/package.json').name")
-              
+
               # Add to arrays
               if [ -z "$EXTENSION_NAMES" ]; then
                 EXTENSION_NAMES="$PACKAGE_NAME"

--- a/.github/workflows/vscode-publish-extensions.yml
+++ b/.github/workflows/vscode-publish-extensions.yml
@@ -636,6 +636,7 @@ jobs:
     name: Publish Skipped Notice
     needs:
       [
+        determine-changes,
         bump-versions,
         package,
         calculate-artifact-name,
@@ -648,7 +649,7 @@ jobs:
         run: |
           echo "ℹ️ Marketplace publishing skipped for this build type"
           echo "  Reason: Nightly builds only create GitHub releases, not marketplace publishes"
-          echo "  Extensions would be published: ${{ inputs.extensions }}"
+          echo "  Extensions would be published: ${{ needs.determine-changes.outputs.selected-extensions }}"
           echo "  Registries configured: ${{ inputs.registries }}"
 
   publish:


### PR DESCRIPTION
## Problem

Consuming repos that call `vscode-publish-extensions.yml` with `extensions: changed` (or `all`) stopped getting GitHub releases from their nightly builds, even though the workflow reported success and tags kept being created.

**Observed in `forcedotcom/apex-language-support`:** nightly tags continue daily (`v0.9.32-nightly.20260729`), but the last GitHub *release* is `v0.9.19-nightly.20260714` — the first nightly after that repo migrated its nightly to `extensions: 'changed'`.

## Root cause

`determine-changes` resolves the `extensions` input (`changed`/`all`/CSV) into concrete extension **directory names** and exposes them as `outputs.selected-extensions`. The `bump-versions` job correctly consumes that resolved output — which is why tags kept working.

But several downstream jobs read the **raw** `inputs.extensions` instead, so with `extensions: changed` they iterated over the literal string `"changed"` as if it were a directory:

- **`create-github-releases`** — looked for `packages/changed/package.json`, didn't find it, `continue`d, then still printed `✅ Releases created`. Silent no-op → no GitHub release. This is the reported breakage.
- **`slack-notify` / `slack-notify-failure`** — reported blank extension names/versions in nightly Slack messages.
- **`determine-publish-matrix`** — reads the raw input too; currently inert for nightly (`IS_NIGHTLY: 'true'` short-circuits to an empty matrix before the input is used), fixed for consistency and future non-nightly use.

Evidence from a live run (`create-github-releases` step):
```
⚠️  Skipping changed: package.json not found
✅ Releases created
```

## Fix

Wire `determine-changes` into each affected job's `needs` and consume `needs.determine-changes.outputs.selected-extensions` instead of `inputs.extensions`. Also gate `create-github-releases` on the resolved output rather than the raw input.

`determine-changes` itself (line ~216) intentionally still reads the raw `inputs.extensions` — it is the resolver.

## Validation

- YAML parses cleanly; `determine-changes` has no `needs`, so no dependency cycle is introduced.
- Verified all four consumers now list `determine-changes` in `needs`.

Full end-to-end confirmation requires a nightly run in a consuming repo (or a `workflow_dispatch` with `extensions: changed`) after this merges to `@main`.