### PR TITLE
@W-23480655: drop win x86 arch from stampy upload

### DIFF
--- a/.github/workflows/stampyUpload.yml
+++ b/.github/workflows/stampyUpload.yml
@@ -25,7 +25,6 @@ jobs:
 
       - name: Download from s3
         run: |
-          aws s3 cp "s3://dfc-data-production/media/salesforce-cli/sf/versions/$INPUTS_VERSION/$STEPS_VERSION_INFO_SHA/$STEPS_FILENAME_FILEBASE-x86.exe" .
           aws s3 cp "s3://dfc-data-production/media/salesforce-cli/sf/versions/$INPUTS_VERSION/$STEPS_VERSION_INFO_SHA/$STEPS_FILENAME_FILEBASE-x64.exe" .
           aws s3 cp "s3://dfc-data-production/media/salesforce-cli/sf/versions/$INPUTS_VERSION/$STEPS_VERSION_INFO_SHA/$STEPS_FILENAME_FILEBASE-arm64.exe" .
         env:
@@ -45,7 +44,6 @@ jobs:
           export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
           export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
           export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
-          aws s3 cp "$STEPS_FILENAME_FILEBASE-x86.exe" "$STAMPY_UNSIGNED_BUCKET/$STEPS_FILENAME_FILEBASE-x86.exe"
           aws s3 cp "$STEPS_FILENAME_FILEBASE-x64.exe" "$STAMPY_UNSIGNED_BUCKET/$STEPS_FILENAME_FILEBASE-x64.exe"
           aws s3 cp "$STEPS_FILENAME_FILEBASE-arm64.exe" "$STAMPY_UNSIGNED_BUCKET/$STEPS_FILENAME_FILEBASE-arm64.exe"
         env:


### PR DESCRIPTION
Drops win x86 arch from stampy signing upload. Part of dropping support for node 18,20 and bumping hte base node version to 24

[@W-23480655@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-23480655)