### PR TITLE
feat: add configurable git identity inputs to vscode-publish-extensions

### DIFF
--- a/.github/workflows/vscode-publish-extensions.yml
+++ b/.github/workflows/vscode-publish-extensions.yml
@@ -103,6 +103,16 @@ on:
         required: false
         default: '22.x'
         type: string
+      git-user-name:
+        description: 'Git user name for version bump commits'
+        required: false
+        default: 'GitHub Action'
+        type: string
+      git-user-email:
+        description: 'Git user email for version bump commits'
+        required: false
+        default: 'action@github.com'
+        type: string
 
 # Add explicit permissions for security
 permissions:
@@ -464,8 +474,8 @@ jobs:
             echo "🔄 Committing version bumps..."
 
             # Configure git for the action
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
+            git config --local user.email "${{ inputs.git-user-email }}"
+            git config --local user.name "${{ inputs.git-user-name }}"
 
             # Configure git to use the PAT for authentication
             git remote set-url origin https://x-access-token:${{ secrets.IDEE_GH_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/vscode-publish-extensions.yml
+++ b/.github/workflows/vscode-publish-extensions.yml
@@ -473,9 +473,25 @@ jobs:
           else
             echo "🔄 Committing version bumps..."
 
-            # Configure git for the action
-            git config --local user.email "${{ inputs.git-user-email }}"
-            git config --local user.name "${{ inputs.git-user-name }}"
+            # Validate git identity inputs (prevent empty strings from overriding defaults)
+            GIT_USER_NAME="${{ inputs.git-user-name }}"
+            GIT_USER_EMAIL="${{ inputs.git-user-email }}"
+
+            if [ -z "$GIT_USER_NAME" ]; then
+              echo "⚠️  git-user-name is empty, using default: GitHub Action"
+              GIT_USER_NAME="GitHub Action"
+            fi
+
+            if [ -z "$GIT_USER_EMAIL" ]; then
+              echo "⚠️  git-user-email is empty, using default: action@github.com"
+              GIT_USER_EMAIL="action@github.com"
+            fi
+
+            # Configure git for the action (using -c flag for safer parameter passing)
+            export GIT_AUTHOR_NAME="$GIT_USER_NAME"
+            export GIT_AUTHOR_EMAIL="$GIT_USER_EMAIL"
+            export GIT_COMMITTER_NAME="$GIT_USER_NAME"
+            export GIT_COMMITTER_EMAIL="$GIT_USER_EMAIL"
 
             # Configure git to use the PAT for authentication
             git remote set-url origin https://x-access-token:${{ secrets.IDEE_GH_TOKEN }}@github.com/${{ github.repository }}.git


### PR DESCRIPTION
Adds configurable git user identity to the vscode-publish-extensions reusable workflow, allowing callers to specify the commit author for version bump commits.

### What does this PR do?

Adds two optional workflow inputs to `.github/workflows/vscode-publish-extensions.yml`:
- `git-user-name`: Git user name for version bump commits (default: 'GitHub Action')
- `git-user-email`: Git user email for version bump commits (default: 'action@github.com')

### Changes:
- Add `git-user-name` and `git-user-email` optional inputs with backward-compatible defaults
- Replace hardcoded git config with configurable identity using environment variables
- Add validation to prevent empty string inputs from causing "empty ident name not allowed" errors
- Use `GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables for safer parameter passing

### Why?

Previously, the workflow hardcoded the git identity as 'GitHub Action <action@github.com>'. This change allows callers to specify a different identity (e.g., 'Release Bot' via `getGithubUserInfo` action) while maintaining backward compatibility with existing callers through sensible defaults.

### Backward Compatibility

✅ Fully backward compatible - inputs are optional with defaults matching the previous hardcoded values. Existing workflows calling this reusable workflow will continue to work without modifications.
