### PR TITLE
feat(vscode): publish release VSIX assets

### DIFF
--- a/.github/actions/vscode/download-release-vsix/action.yml
+++ b/.github/actions/vscode/download-release-vsix/action.yml
@@ -1,0 +1,46 @@
+name: Download Release VSIXs
+description: Download VSIX assets from a GitHub release and determine its release type
+
+inputs:
+  release-tag:
+    description: GitHub release tag containing the VSIX assets
+    required: true
+
+outputs:
+  pre-release:
+    description: Whether the GitHub release is a pre-release
+    value: ${{ steps.release-type.outputs.pre-release }}
+
+runs:
+  using: composite
+  steps:
+    - name: Download VSIXs
+      id: download
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        mkdir extensions
+        gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern '*.vsix' --dir extensions
+
+        if ! find extensions -type f -name '*.vsix' -print -quit | grep -q .; then
+          echo "No VSIX files found in release $RELEASE_TAG"
+          exit 1
+        fi
+
+        echo 'Downloaded VSIX files:'
+        find extensions -type f -name '*.vsix'
+
+    - name: Detect release type
+      id: release-type
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ inputs.release-tag }}
+      run: |
+        if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease | grep -qx true; then
+          echo 'pre-release=true' >> "$GITHUB_OUTPUT"
+        else
+          echo 'pre-release=false' >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/openvsx-publish-release-vsix.yml
+++ b/.github/workflows/openvsx-publish-release-vsix.yml
@@ -1,0 +1,59 @@
+name: Publish Release VSIXs to Open VSX
+
+on:
+  workflow_call:
+    inputs:
+      release-tag:
+        description: GitHub release tag containing the VSIX assets
+        required: true
+        type: string
+    secrets:
+      IDEE_OVSX_PAT:
+        description: Open VSX publishing token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release VSIXs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: |
+          mkdir extensions
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern '*.vsix' --dir extensions
+
+          shopt -s nullglob
+          vsix_files=(extensions/*.vsix)
+          if [ ${#vsix_files[@]} -eq 0 ]; then
+            echo "No VSIX files found in release $RELEASE_TAG"
+            exit 1
+          fi
+
+          echo 'Downloaded VSIX files:'
+          printf '%s\n' "${vsix_files[@]}"
+
+      - name: Detect release type
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease | grep -qx true; then
+            echo 'PRE_RELEASE_FLAG=--pre-release' >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish VSIXs
+        env:
+          IDEE_OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
+        run: |
+          for vsix in extensions/*.vsix; do
+            args=("$vsix" -p "$IDEE_OVSX_PAT" --skip-duplicate)
+            if [ -n "$PRE_RELEASE_FLAG" ]; then
+              args+=(--pre-release)
+            fi
+            npx ovsx publish "${args[@]}"
+          done

--- a/.github/workflows/openvsx-publish-release-vsix.yml
+++ b/.github/workflows/openvsx-publish-release-vsix.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Download release VSIXs
         id: release
-        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@main
+        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@03cb2583f2edf45cd7d2688f2a452ee29511229e
         with:
           release-tag: ${{ inputs.release-tag }}
 

--- a/.github/workflows/openvsx-publish-release-vsix.yml
+++ b/.github/workflows/openvsx-publish-release-vsix.yml
@@ -7,6 +7,11 @@ on:
         description: GitHub release tag containing the VSIX assets
         required: true
         type: string
+      dry-run:
+        description: Download and inspect VSIXs without publishing
+        required: false
+        default: false
+        type: boolean
     secrets:
       IDEE_OVSX_PAT:
         description: Open VSX publishing token
@@ -27,13 +32,22 @@ jobs:
 
       - name: Publish VSIXs
         env:
+          DRY_RUN: ${{ inputs.dry-run }}
           IDEE_OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
           PRE_RELEASE: ${{ steps.release.outputs.pre-release }}
         run: |
           while IFS= read -r -d '' vsix; do
             args=("$vsix" -p "$IDEE_OVSX_PAT" --skip-duplicate)
+            pre_release_suffix=''
             if [ "$PRE_RELEASE" = true ]; then
               args+=(--pre-release)
+              pre_release_suffix=' --pre-release'
             fi
+
+            if [ "$DRY_RUN" = true ]; then
+              echo "Would publish $vsix to Open VSX with --skip-duplicate${pre_release_suffix}"
+              continue
+            fi
+
             npx ovsx publish "${args[@]}"
           done < <(find extensions -type f -name '*.vsix' -print0)

--- a/.github/workflows/openvsx-publish-release-vsix.yml
+++ b/.github/workflows/openvsx-publish-release-vsix.yml
@@ -20,40 +20,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release VSIXs
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release-tag }}
-        run: |
-          mkdir extensions
-          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern '*.vsix' --dir extensions
-
-          shopt -s nullglob
-          vsix_files=(extensions/*.vsix)
-          if [ ${#vsix_files[@]} -eq 0 ]; then
-            echo "No VSIX files found in release $RELEASE_TAG"
-            exit 1
-          fi
-
-          echo 'Downloaded VSIX files:'
-          printf '%s\n' "${vsix_files[@]}"
-
-      - name: Detect release type
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release-tag }}
-        run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease | grep -qx true; then
-            echo 'PRE_RELEASE_FLAG=--pre-release' >> "$GITHUB_ENV"
-          fi
+        id: release
+        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@main
+        with:
+          release-tag: ${{ inputs.release-tag }}
 
       - name: Publish VSIXs
         env:
           IDEE_OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
+          PRE_RELEASE: ${{ steps.release.outputs.pre-release }}
         run: |
-          for vsix in extensions/*.vsix; do
+          while IFS= read -r -d '' vsix; do
             args=("$vsix" -p "$IDEE_OVSX_PAT" --skip-duplicate)
-            if [ -n "$PRE_RELEASE_FLAG" ]; then
+            if [ "$PRE_RELEASE" = true ]; then
               args+=(--pre-release)
             fi
             npx ovsx publish "${args[@]}"
-          done
+          done < <(find extensions -type f -name '*.vsix' -print0)

--- a/.github/workflows/vscode-publish-release-vsix.yml
+++ b/.github/workflows/vscode-publish-release-vsix.yml
@@ -20,40 +20,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release VSIXs
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release-tag }}
-        run: |
-          mkdir extensions
-          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern '*.vsix' --dir extensions
-
-          shopt -s nullglob
-          vsix_files=(extensions/*.vsix)
-          if [ ${#vsix_files[@]} -eq 0 ]; then
-            echo "No VSIX files found in release $RELEASE_TAG"
-            exit 1
-          fi
-
-          echo 'Downloaded VSIX files:'
-          printf '%s\n' "${vsix_files[@]}"
-
-      - name: Detect release type
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release-tag }}
-        run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease | grep -qx true; then
-            echo 'PRE_RELEASE_FLAG=--pre-release' >> "$GITHUB_ENV"
-          fi
+        id: release
+        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@main
+        with:
+          release-tag: ${{ inputs.release-tag }}
 
       - name: Publish VSIXs
         env:
+          PRE_RELEASE: ${{ steps.release.outputs.pre-release }}
           VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
         run: |
-          for vsix in extensions/*.vsix; do
+          while IFS= read -r -d '' vsix; do
             args=(--packagePath "$vsix" --skip-duplicate)
-            if [ -n "$PRE_RELEASE_FLAG" ]; then
+            if [ "$PRE_RELEASE" = true ]; then
               args+=(--pre-release)
             fi
             VSCE_PAT="$VSCE_PERSONAL_ACCESS_TOKEN" npx @vscode/vsce publish "${args[@]}"
-          done
+          done < <(find extensions -type f -name '*.vsix' -print0)

--- a/.github/workflows/vscode-publish-release-vsix.yml
+++ b/.github/workflows/vscode-publish-release-vsix.yml
@@ -7,6 +7,11 @@ on:
         description: GitHub release tag containing the VSIX assets
         required: true
         type: string
+      dry-run:
+        description: Download and inspect VSIXs without publishing
+        required: false
+        default: false
+        type: boolean
     secrets:
       VSCE_PERSONAL_ACCESS_TOKEN:
         description: VS Code Marketplace publishing token
@@ -27,6 +32,7 @@ jobs:
 
       - name: Publish VSIXs
         env:
+          DRY_RUN: ${{ inputs.dry-run }}
           PRE_RELEASE: ${{ steps.release.outputs.pre-release }}
           VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
         run: |
@@ -35,5 +41,11 @@ jobs:
             if [ "$PRE_RELEASE" = true ]; then
               args+=(--pre-release)
             fi
+
+            if [ "$DRY_RUN" = true ]; then
+              echo "Would publish $vsix to the VS Code Marketplace: @vscode/vsce publish ${args[*]}"
+              continue
+            fi
+
             VSCE_PAT="$VSCE_PERSONAL_ACCESS_TOKEN" npx @vscode/vsce publish "${args[@]}"
           done < <(find extensions -type f -name '*.vsix' -print0)

--- a/.github/workflows/vscode-publish-release-vsix.yml
+++ b/.github/workflows/vscode-publish-release-vsix.yml
@@ -1,0 +1,59 @@
+name: Publish Release VSIXs to VS Code Marketplace
+
+on:
+  workflow_call:
+    inputs:
+      release-tag:
+        description: GitHub release tag containing the VSIX assets
+        required: true
+        type: string
+    secrets:
+      VSCE_PERSONAL_ACCESS_TOKEN:
+        description: VS Code Marketplace publishing token
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release VSIXs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: |
+          mkdir extensions
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern '*.vsix' --dir extensions
+
+          shopt -s nullglob
+          vsix_files=(extensions/*.vsix)
+          if [ ${#vsix_files[@]} -eq 0 ]; then
+            echo "No VSIX files found in release $RELEASE_TAG"
+            exit 1
+          fi
+
+          echo 'Downloaded VSIX files:'
+          printf '%s\n' "${vsix_files[@]}"
+
+      - name: Detect release type
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq .isPrerelease | grep -qx true; then
+            echo 'PRE_RELEASE_FLAG=--pre-release' >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish VSIXs
+        env:
+          VSCE_PERSONAL_ACCESS_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
+        run: |
+          for vsix in extensions/*.vsix; do
+            args=(--packagePath "$vsix" --skip-duplicate)
+            if [ -n "$PRE_RELEASE_FLAG" ]; then
+              args+=(--pre-release)
+            fi
+            VSCE_PAT="$VSCE_PERSONAL_ACCESS_TOKEN" npx @vscode/vsce publish "${args[@]}"
+          done

--- a/.github/workflows/vscode-publish-release-vsix.yml
+++ b/.github/workflows/vscode-publish-release-vsix.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Download release VSIXs
         id: release
-        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@main
+        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@03cb2583f2edf45cd7d2688f2a452ee29511229e
         with:
           release-tag: ${{ inputs.release-tag }}
 

--- a/README.md
+++ b/README.md
@@ -642,6 +642,32 @@ jobs:
 - `version-bump` (optional) - Version bump type: `auto`, `patch`, `minor`, `major` (default: `auto`)
 - `slack-notification-title` (optional) - Slack notification title (default: `🎉 Extensions Released Successfully!`)
 
+### vscode-publish-release-vsix
+
+Downloads every VSIX asset from a GitHub release in the calling repository and publishes it to the VS Code Marketplace. The release's pre-release state is preserved, and already-published versions are skipped.
+
+```yaml
+jobs:
+  publish:
+    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
+    with:
+      release-tag: v67.10.0
+    secrets: inherit
+```
+
+### openvsx-publish-release-vsix
+
+Downloads every VSIX asset from a GitHub release in the calling repository and publishes it to Open VSX. The release's pre-release state is preserved, and already-published versions are skipped.
+
+```yaml
+jobs:
+  publish:
+    uses: salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@main
+    with:
+      release-tag: v67.10.0
+    secrets: inherit
+```
+
 ### vscode-promote-prerelease
 
 Promotes a vetted nightly build to pre-release on VS Code Marketplace and Open VSX. This workflow finds the oldest unpromoted nightly that meets the minimum age requirement, verifies CI checks passed, and publishes it as a pre-release.

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ jobs:
 
 ### vscode-publish-release-vsix
 
-Downloads every VSIX asset from a GitHub release in the calling repository and publishes it to the VS Code Marketplace. The release's pre-release state is preserved, and already-published versions are skipped.
+Downloads every VSIX asset from a GitHub release in the calling repository and publishes it to the VS Code Marketplace. VSIX files are found recursively, the release's pre-release state is preserved, and already-published versions are skipped.
 
 ```yaml
 jobs:
@@ -657,7 +657,7 @@ jobs:
 
 ### openvsx-publish-release-vsix
 
-Downloads every VSIX asset from a GitHub release in the calling repository and publishes it to Open VSX. The release's pre-release state is preserved, and already-published versions are skipped.
+Downloads every VSIX asset from a GitHub release in the calling repository and publishes it to Open VSX. VSIX files are found recursively, the release's pre-release state is preserved, and already-published versions are skipped.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: v67.10.0
+      dry-run: true # Download and inspect without publishing
     secrets: inherit
 ```
 
@@ -665,6 +666,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@main
     with:
       release-tag: v67.10.0
+      dry-run: true # Download and inspect without publishing
     secrets: inherit
 ```
 


### PR DESCRIPTION
## Summary
- Add separate reusable workflows that publish every VSIX attached to a caller repository release to VS Code Marketplace or Open VSX.
- Share release download, recursive VSIX discovery, and prerelease detection in a composite action.
- Preserve the GitHub release pre-release state, skip duplicate marketplace versions, and support safe workflow-level dry runs.
- Document both release-asset publisher workflows.

## Verification
- `actionlint .github/workflows/vscode-publish-release-vsix.yml .github/workflows/openvsx-publish-release-vsix.yml`
- YAML parsing and Prettier checks for the new action and workflows.
- Downloaded and inspected the 17 VSIX assets from `forcedotcom/salesforcedx-vscode` release `v67.10.0`; confirmed its stable release state and flat asset layout.
- Tested recursive nested VSIX discovery and both dry-run paths; neither invokes a publish CLI, and the Open VSX token is not logged.

### What issues does this PR fix or reference?
No related issues or discussions.

[skip-validate-pr]