### PR TITLE
fix: configure VS Code promotion gates

### DIFF
--- a/.github/workflows/vscode-promote-prerelease.yml
+++ b/.github/workflows/vscode-promote-prerelease.yml
@@ -11,6 +11,7 @@ name: Promote Nightly to Pre-release
 #         min-tag-age-days: '7'
 #         vsix-name-pattern: 'apex-language-server-extension-*.vsix'  # optional, default: *.vsix
 #         exclude-web-vsix: 'true'  # optional, default: false
+#         required-ci-checks: '["CI Complete"]'
 #         dry-run: 'false'
 #       secrets: inherit
 #
@@ -44,6 +45,11 @@ on:
         description: "Exclude *-web-* VSIX files from promotion"
         required: false
         default: "false"
+        type: string
+      required-ci-checks:
+        description: "JSON array of CI check names required before promotion"
+        required: false
+        default: '["CI Complete"]'
         type: string
       dry-run:
         description: "Run in dry-run mode (no actual publishing or tagging)"
@@ -79,6 +85,11 @@ on:
         options:
           - "false"
           - "true"
+      required-ci-checks:
+        description: "JSON array of CI check names required before promotion"
+        required: false
+        default: '["CI Complete"]'
+        type: string
       dry-run:
         description: "Run in dry-run mode (no actual publishing or tagging)"
         required: false
@@ -188,6 +199,9 @@ jobs:
         with:
           commit-sha: ${{ needs.find-nightly-candidate.outputs.commit-sha }}
           token: ${{ secrets.IDEE_GH_TOKEN }}
+          # `CI Complete` is the aggregate release gate emitted by vscode-ci-template.
+          # Callers can override it for their repository's release-worthy checks.
+          required-checks: ${{ inputs.required-ci-checks }}
 
   publish:
     needs: [find-nightly-candidate, quality-gate]

--- a/.github/workflows/vscode-promote-stable.yml
+++ b/.github/workflows/vscode-promote-stable.yml
@@ -11,6 +11,7 @@ name: Promote Pre-release to Stable
 #         vsix-name-pattern: 'apex-language-server-extension-*.vsix'
 #         exclude-web-vsix: 'true'
 #         extensions-root: 'packages'
+#         required-ci-checks: '["CI Complete"]'
 #         dry-run: 'false'
 #       secrets: inherit
 #
@@ -18,7 +19,7 @@ name: Promote Pre-release to Stable
 #   - marketplace-prerelease-* tracking tags
 #   - Nightly tags matching v{version}-nightly.* pattern
 #   - GitHub releases for each nightly tag with VSIX file(s) attached
-#   - Passing CI checks (gate, tag-published)
+#   - Passing CI checks on the nightly candidate commit
 #   - Secrets: IDEE_GH_TOKEN, VSCE_PERSONAL_ACCESS_TOKEN, IDEE_OVSX_PAT
 #   - The shared actions in this repository are resolved from the workflow branch.
 #   - The package manager and lockfile inputs must match the caller repository.
@@ -51,6 +52,11 @@ on:
         description: 'Root directory for extensions (default: packages)'
         required: false
         default: 'packages'
+        type: string
+      required-ci-checks:
+        description: 'JSON array of CI check names required before promotion'
+        required: false
+        default: '["CI Complete"]'
         type: string
       dry-run:
         description: 'Run in dry-run mode (no actual publishing or tagging)'
@@ -110,6 +116,11 @@ on:
         description: 'Root directory for extensions (default: packages)'
         required: false
         default: 'packages'
+        type: string
+      required-ci-checks:
+        description: 'JSON array of CI check names required before promotion'
+        required: false
+        default: '["CI Complete"]'
         type: string
       dry-run:
         description: 'Run in dry-run mode (no actual publishing or tagging)'
@@ -261,13 +272,14 @@ jobs:
         with:
           commit-sha: ${{ needs.find-prerelease-candidate.outputs.commit-sha }}
           token: ${{ secrets.IDEE_GH_TOKEN }}
-          # Validate only the publish-pipeline checks that gate the candidate's quality.
+          # Validate only checks produced on the nightly candidate commit.
           # Without this, the action validates every check-run on the commit — including
           # this workflow's own `quality-gate` job, whose superseded historical runs can
           # carry a stale `failure` conclusion and block all future promotions.
-          # `gate` is the Manual Publish aggregate gate; `tag-published` confirms the
-          # nightly/pre-release artifact was successfully published for this commit.
-          required-checks: '["gate","tag-published"]'
+          # `CI Complete` is the aggregate release gate emitted by vscode-ci-template.
+          # The marketplace-prerelease tracking tag found above proves prerelease publication.
+          # Callers can override the CI check names for their repository.
+          required-checks: ${{ inputs.required-ci-checks }}
 
   repackage:
     needs: [find-prerelease-candidate, quality-gate]

--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ jobs:
       min-tag-age-days: '7' # Nightly must be at least 7 days old
       vsix-name-pattern: 'my-extension-*.vsix' # Pattern to match VSIX files
       exclude-web-vsix: 'true' # Exclude *-web-* VSIX files
+      required-ci-checks: '["CI Complete"]'
       dry-run: 'false'
     secrets: inherit
 ```
@@ -694,6 +695,8 @@ jobs:
 - Nightly tags matching `v{version}-nightly.*` pattern (e.g., `v1.2.3-nightly.20260709`)
 - GitHub releases for each nightly tag with VSIX files attached
 - Passing CI checks on nightly commits
+
+`required-ci-checks` is a JSON array of check-run names that must pass on the nightly commit. It defaults to `["CI Complete"]`, the aggregate release gate emitted by `vscode-ci-template.yml`; set it to the matching checks from the calling repository's CI workflow.
 
 **How it works:**
 
@@ -718,6 +721,7 @@ jobs:
       vsix-name-pattern: 'my-extension-*.vsix'
       exclude-web-vsix: 'true'
       extensions-root: 'packages'
+      required-ci-checks: '["CI Complete"]'
       dry-run: 'false'
     secrets: inherit
 ```
@@ -726,6 +730,8 @@ jobs:
 
 - `marketplace-prerelease-*` tracking tags from previous promotions
 - Local actions in calling repository (see Prerequisites section above)
+
+`required-ci-checks` is a JSON array of check-run names that must pass on the nightly candidate commit. It defaults to `["CI Complete"]`, the aggregate release gate emitted by `vscode-ci-template.yml`; set it to the matching CI checks from the calling repository. The required `marketplace-prerelease-*` tracking tag is separate evidence that the prerelease marketplace publication completed.
 
 **Note:** This workflow requires local actions. For a fully self-contained alternative, use `vscode-promote-prerelease.yml`.
 


### PR DESCRIPTION
## Summary
- add a configurable `required-ci-checks` input to nightly-to-prerelease and prerelease-to-stable workflows
- default both promotion gates to `CI Complete`, which is emitted on the candidate nightly commit
- retain prerelease tracking tags as the evidence of marketplace publication and document caller configuration

## Problem
Stable promotion of Apex Language Support prerelease `0.9.49` queried the original nightly commit but required `gate` and `tag-published`. Those check-runs belong to the later manual-publish workflow dispatch commit, so they were absent despite successful CI and prerelease publication.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/vscode-promote-prerelease.yml"); YAML.load_file(".github/workflows/vscode-promote-stable.yml")'`\n- `git diff --check`\n\nGUS: W-23936476