### PR TITLE
fix: auto-derive cache-dependency-path from packageManager input

### DIFF
--- a/.github/workflows/ctcClose.yml
+++ b/.github/workflows/ctcClose.yml
@@ -26,9 +26,9 @@ on:
         default: '10'
         required: false
       cache-dependency-path:
-        description: Path to the calling repository's package manager lockfile
+        description: Path to the calling repository's package manager lockfile; auto-derived from package-manager if not set
         type: string
-        default: package-lock.json
+        default: ''
         required: false
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ inputs.package-manager }}
-          cache-dependency-path: ${{ inputs.cache-dependency-path }}
+          cache-dependency-path: ${{ inputs.cache-dependency-path || (inputs.package-manager == 'yarn' && 'yarn.lock' || (inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json')) }}
       - run: npm install -g @salesforce/change-case-management --omit=dev
       - id: ctc
         run: |

--- a/.github/workflows/ctcOpen.yml
+++ b/.github/workflows/ctcOpen.yml
@@ -20,9 +20,9 @@ on:
         default: '10'
         required: false
       cache-dependency-path:
-        description: Path to the calling repository's package manager lockfile
+        description: Path to the calling repository's package manager lockfile; auto-derived from package-manager if not set
         type: string
-        default: package-lock.json
+        default: ''
         required: false
     outputs:
       changeCaseId:
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ inputs.package-manager }}
-          cache-dependency-path: ${{ inputs.cache-dependency-path }}
+          cache-dependency-path: ${{ inputs.cache-dependency-path || (inputs.package-manager == 'yarn' && 'yarn.lock' || (inputs.package-manager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json')) }}
 
       - run: npm install -g @salesforce/change-case-management --omit=dev
 

--- a/.github/workflows/npmPublish.yml
+++ b/.github/workflows/npmPublish.yml
@@ -62,9 +62,9 @@ on:
         default: '10'
         type: string
       cacheDependencyPath:
-        description: path to the package manager lockfile; defaults to yarn.lock, so npm and pnpm callers must override it
+        description: path to the package manager lockfile; auto-derived from packageManager if not set
         required: false
-        default: yarn.lock
+        default: ''
         type: string
       vulnerabilityCheck:
         description: if true, checks for known vulnerable package versions
@@ -134,7 +134,7 @@ jobs:
       nodeVersion: ${{ inputs.nodeVersion }}
       package-manager: ${{ inputs.packageManager }}
       package-manager-version: ${{ inputs.packageManagerVersion }}
-      cache-dependency-path: ${{ inputs.cacheDependencyPath }}
+      cache-dependency-path: ${{ inputs.cacheDependencyPath || (inputs.packageManager == 'yarn' && 'yarn.lock' || (inputs.packageManager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json')) }}
     secrets: inherit
 
   npm-publish:
@@ -158,7 +158,7 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
           cache: ${{ inputs.packageManager }}
-          cache-dependency-path: ${{ inputs.cacheDependencyPath }}
+          cache-dependency-path: ${{ inputs.cacheDependencyPath || (inputs.packageManager == 'yarn' && 'yarn.lock' || (inputs.packageManager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json')) }}
       - name: Install dependencies with yarn
         if: inputs.packageManager == 'yarn'
         uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@ph/W-23832274-pnpm-stable-promotion
@@ -231,7 +231,7 @@ jobs:
       nodeVersion: ${{ inputs.nodeVersion }}
       package-manager: ${{ inputs.packageManager }}
       package-manager-version: ${{ inputs.packageManagerVersion }}
-      cache-dependency-path: ${{ inputs.cacheDependencyPath }}
+      cache-dependency-path: ${{ inputs.cacheDependencyPath || (inputs.packageManager == 'yarn' && 'yarn.lock' || (inputs.packageManager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json')) }}
 
   ctcCloseFail:
     needs: [ctc-open, npm-publish]
@@ -244,4 +244,4 @@ jobs:
       status: Not Implemented
       package-manager: ${{ inputs.packageManager }}
       package-manager-version: ${{ inputs.packageManagerVersion }}
-      cache-dependency-path: ${{ inputs.cacheDependencyPath }}
+      cache-dependency-path: ${{ inputs.cacheDependencyPath || (inputs.packageManager == 'yarn' && 'yarn.lock' || (inputs.packageManager == 'pnpm' && 'pnpm-lock.yaml' || 'package-lock.json')) }}


### PR DESCRIPTION
## Summary

- Remove hardcoded defaults for `cache-dependency-path` (was `yarn.lock` in npmPublish, `package-lock.json` in ctcOpen/ctcClose)
- Auto-derive the lockfile path from the `packageManager`/`package-manager` input when not explicitly set: yarn → `yarn.lock`, pnpm → `pnpm-lock.yaml`, npm → `package-lock.json`
- Fixes `salesforce-metadata-plugins` (and any other npm repo) failing in npmPublish with `"Some specified paths were not resolved, unable to cache dependencies"`

## Context

This is the inverse of salesforcecli/cli#2882 — that PR fixed the CLI (a yarn repo) getting npm defaults in ctcOpen. Now npm repos calling npmPublish were getting the `yarn.lock` default. This fix makes all three workflows self-consistent regardless of which package manager the caller uses.

Reported by Pallav Agarwal in #platform-cli-collaboration.

## Test plan

- [ ] Re-run `salesforce-metadata-plugins` publish workflow (npm repo, no `cacheDependencyPath` override) — should pass
- [ ] Verify CLI promote workflow still passes (yarn repo, explicitly passes `cache-dependency-path: yarn.lock`)
- [ ] Verify any pnpm repo passing `packageManager: pnpm` resolves to `pnpm-lock.yaml`