### PR TITLE
chore: unpin download-release-vsix action to use @main

### DIFF
--- a/.github/workflows/openvsx-publish-release-vsix.yml
+++ b/.github/workflows/openvsx-publish-release-vsix.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Download release VSIXs
         id: release
-        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@03cb2583f2edf45cd7d2688f2a452ee29511229e
+        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@main
         with:
           release-tag: ${{ inputs.release-tag }}
 

--- a/.github/workflows/vscode-publish-release-vsix.yml
+++ b/.github/workflows/vscode-publish-release-vsix.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Download release VSIXs
         id: release
-        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@03cb2583f2edf45cd7d2688f2a452ee29511229e
+        uses: salesforcecli/github-workflows/.github/actions/vscode/download-release-vsix@main
         with:
           release-tag: ${{ inputs.release-tag }}
 


### PR DESCRIPTION
Remove hardcoded SHA reference to allow automatic updates to the action.

Background:
- Action was pinned to SHA 03cb2583f in commit d8eed42fb (Aug 2026)
- Pinning was done during initial development for stability
- SHA is confirmed to be in main branch ancestry
- Action has been stable for months

Changes:
- vscode-publish-release-vsix.yml: Use @main instead of @03cb2583f
- openvsx-publish-release-vsix.yml: Use @main instead of @03cb2583f

Benefits:
- Workflows automatically get action updates/fixes
- No need to manually update SHA after action changes
- Consistent with other action references in the repo